### PR TITLE
Control center images new repo fixes

### DIFF
--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -86,7 +86,7 @@ COPY --from=builder /usr/libexec/confluent-control-center/linux_$ARCH/alertmanag
 COPY --from=builder /etc/confluent-control-center/alertmanager-generated.yml /etc/alertmanager/alertmanager-generated.yml
 
 
-RUN for file in bin/alertmanager/alertmanager*; do mv "$file" bin/alertmanager/alertmanager; done
+RUN for file in /bin/alertmanager/alertmanager*; do mv "$file" /bin/alertmanager/alertmanager; done
 
 EXPOSE 9093
 

--- a/alertmanager/pom.xml
+++ b/alertmanager/pom.xml
@@ -21,12 +21,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.confluent.control-center-images</groupId>
-        <artifactId>control-center-images-parent</artifactId>
+        <groupId>io.confluent.control-center-images-next-gen</groupId>
+        <artifactId>control-center-images-parent-next-gen</artifactId>
         <version>8.0.0-0</version>
     </parent>
 
-    <groupId>io.confluent.control-center-images</groupId>
+    <groupId>io.confluent.control-center-images-next-gen</groupId>
     <artifactId>cp-enterprise-alertmanager</artifactId>
     <name>Control Center AlertManager Image</name>
 

--- a/alertmanager/pom.xml
+++ b/alertmanager/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~
+  ~ Copyright 2019 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.confluent.control-center-images</groupId>
+        <artifactId>control-center-images-parent</artifactId>
+        <version>8.0.0-0</version>
+    </parent>
+
+    <groupId>io.confluent.control-center-images</groupId>
+    <artifactId>cp-enterprise-alertmanager</artifactId>
+    <name>Control Center AlertManager Image</name>
+
+    <properties>
+        <docker.skip-build>false</docker.skip-build>
+        <docker.skip-test>true</docker.skip-test>
+    </properties>
+
+</project>

--- a/control-center/pom.xml
+++ b/control-center/pom.xml
@@ -21,14 +21,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.confluent.control-center-images</groupId>
-        <artifactId>control-center-images-parent</artifactId>
+        <groupId>io.confluent.control-center-images-next-gen</groupId>
+        <artifactId>control-center-images-parent-next-gen</artifactId>
         <version>8.0.0-0</version>
     </parent>
 
-    <groupId>io.confluent.control-center-images</groupId>
-    <artifactId>cp-enterprise-control-center</artifactId>
-    <name>Control Center Docker Image</name>
+    <groupId>io.confluent.control-center-images-next-gen</groupId>
+    <artifactId>cp-enterprise-control-center-next-gen</artifactId>
+    <name>Control Center Next Gen Docker Image</name>
 
     <properties>
         <docker.skip-build>false</docker.skip-build>

--- a/control-center/test/fixtures/standalone-config.yml
+++ b/control-center/test/fixtures/standalone-config.yml
@@ -21,14 +21,14 @@ services:
       - io.confluent.docker.testing=true
 
   failing-config:
-    image: confluentinc/cp-enterprise-control-center:latest
+    image: confluentinc/cp-enterprise-control-center-next-gen:latest
     labels:
       - io.confluent.docker.testing=true
 
   failing-config-missing-zk-connect:
     environment:
       CONTROL_CENTER_BOOTSTRAP_SERVERS: fake
-    image: confluentinc/cp-enterprise-control-center:latest
+    image: confluentinc/cp-enterprise-control-center-next-gen:latest
     labels:
       - io.confluent.docker.testing=true
 
@@ -36,12 +36,12 @@ services:
     environment:
       CONTROL_CENTER_BOOTSTRAP_SERVERS: fakeKafka
       CONTROL_CENTER_ZOOKEEPER_CONNECT: fakeZk
-    image: confluentinc/cp-enterprise-control-center:latest
+    image: confluentinc/cp-enterprise-control-center-next-gen:latest
     labels:
       - io.confluent.docker.testing=true
 
   default-config:
-    image: confluentinc/cp-enterprise-control-center:latest
+    image: confluentinc/cp-enterprise-control-center-next-gen:latest
     environment:
       CONTROL_CENTER_ZOOKEEPER_CONNECT: "zookeeper:2181/defaultconfig"
       CONTROL_CENTER_BOOTSTRAP_SERVERS: "kafka:9092"
@@ -50,7 +50,7 @@ services:
       - io.confluent.docker.testing=true
 
   wildcards-config:
-    image: confluentinc/cp-enterprise-control-center:latest
+    image: confluentinc/cp-enterprise-control-center-next-gen:latest
     command: "bash -c '/etc/confluent/docker/configure && touch /tmp/config-is-done && sleep infinity'"
     environment:
       CONTROL_CENTER_ZOOKEEPER_CONNECT: "zookeeper:2181/defaultconfig"
@@ -81,7 +81,7 @@ services:
       - io.confluent.docker.testing=true
 
   security-config-with-producer-override:
-    image: confluentinc/cp-enterprise-control-center:latest
+    image: confluentinc/cp-enterprise-control-center-next-gen:latest
     command: "bash -c '/etc/confluent/docker/configure && touch /tmp/config-is-done && sleep infinity'"
     environment:
       CONTROL_CENTER_ZOOKEEPER_CONNECT: "zookeeper:2181/defaultconfig"

--- a/control-center/test/fixtures/standalone-network.yml
+++ b/control-center/test/fixtures/standalone-network.yml
@@ -39,7 +39,7 @@ services:
       - zk
     ports:
       - "19021:9021"
-    image: confluentinc/cp-enterprise-control-center:latest
+    image: confluentinc/cp-enterprise-control-center-next-gen:latest
     environment:
       CONTROL_CENTER_ZOOKEEPER_CONNECT: "zookeeper-bridge:2181"
       CONTROL_CENTER_BOOTSTRAP_SERVERS: "kafka-bridge:19092"

--- a/control-center/test/test_control_center.py
+++ b/control-center/test/test_control_center.py
@@ -6,7 +6,7 @@ import json
 
 import confluent.docker_utils as utils
 
-IMAGE_NAME = 'confluentinc/cp-enterprise-control-center'
+IMAGE_NAME = 'confluentinc/cp-enterprise-control-center-next-gen'
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 FIXTURES_DIR = os.path.join(CURRENT_DIR, "fixtures")
 KAFKA_READY = "bash -c 'cub kafka-ready {brokers} 40 -z $KAFKA_ZOOKEEPER_CONNECT && echo PASS || echo FAIL'"

--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,10 @@
     <description>Build files for Confluent's control center Docker images</description>
     <version>8.0.0-0</version>
 
-    <modules>
+   <modules>
         <module>control-center</module>
+        <module>prometheus</module>
+        <module>alertmanager</module>
     </modules>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
         <version>[8.0.0-0, 8.0.1-0)</version>
     </parent>
 
-    <groupId>io.confluent.control-center-images</groupId>
-    <artifactId>control-center-images-parent</artifactId>
+    <groupId>io.confluent.control-center-images-next-gen</groupId>
+    <artifactId>control-center-images-parent-next-gen</artifactId>
     <packaging>pom</packaging>
     <name>Control Center Docker Images</name>
     <description>Build files for Confluent's control center Docker images</description>

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -87,7 +87,7 @@ COPY --from=builder /etc/confluent-control-center/prometheus-generated.yml /etc/
 COPY --from=builder /etc/confluent-control-center/trigger_rules-generated.yml /etc/prometheus/
 COPY --from=builder /etc/confluent-control-center/recording_rules-generated.yml /etc/prometheus/
 
-RUN for file in bin/prometheus/prometheus*; do mv "$file" bin/prometheus/prometheus; done
+RUN for file in /bin/prometheus/prometheus*; do mv "$file" /bin/prometheus/prometheus; done
 
 EXPOSE 9090
 

--- a/prometheus/pom.xml
+++ b/prometheus/pom.xml
@@ -21,8 +21,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.confluent.control-center-images</groupId>
-        <artifactId>control-center-images-parent</artifactId>
+        <groupId>io.confluent.control-center-images-next-gen</groupId>
+        <artifactId>control-center-images-parent-next-gen</artifactId>
         <version>8.0.0-0</version>
     </parent>
 

--- a/prometheus/pom.xml
+++ b/prometheus/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~
+  ~ Copyright 2019 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.confluent.control-center-images</groupId>
+        <artifactId>control-center-images-parent</artifactId>
+        <version>8.0.0-0</version>
+    </parent>
+
+    <groupId>io.confluent.control-center-images</groupId>
+    <artifactId>cp-enterprise-prometheus</artifactId>
+    <name>Control Center Prometheus Image</name>
+
+    <properties>
+        <docker.skip-build>false</docker.skip-build>
+        <docker.skip-test>true</docker.skip-test>
+    </properties>
+
+</project>

--- a/service.yml
+++ b/service.yml
@@ -1,11 +1,67 @@
-name: control-center-next-gen-images
-lang: unknown
-lang_version: unknown
+name: control-center-images-next-gen
+lang: python
+lang_version: 3.12
 git:
   enable: true
 codeowners:
   enable: true
-renovatebot:
+semaphore:
   enable: true
-  automerge:
-    enable: true
+  pipeline_type: cp-dockerfile
+  docker_repos: ["confluentinc/cp-enterprise-control-center-next-gen", "confluentinc/cp-enterprise-prometheus", "confluentinc/cp-enterprise-alertmanager"]
+  maven_phase: 'package'
+  maven_skip_deploy: true
+  build_arm: true
+  sign_images: true
+  os_types: ["ubi9"]
+  nano_version: true
+  use_packages: true
+  cp_images: true
+  push_latest: true
+  tasks:
+    - name: cp-dockerfile-build
+      branch: master
+      pipeline_file: .semaphore/cp_dockerfile_build.yml
+      parameters:
+        - name: CONFLUENT_VERSION
+          required: true
+        - name: PACKAGES_URL
+          required: true
+        - name: PACKAGES_MAVEN_URL
+          required: true
+        - name: PACKAGING_BUILD_NUMBER
+          required: true
+        - name: ALLOW_UNSIGNED
+          required: true
+          default_value: 'False'
+          options:
+            - 'True'
+            - 'False'
+        - name: CONFLUENT_DEB_VERSION
+          required: true
+          default_value: '1'
+    - name: cp-dockerfile-promote
+      branch: master
+      pipeline_file: .semaphore/cp_dockerfile_promote.yml
+      parameters:
+        - name: CONFLUENT_VERSION
+          required: true
+        - name: IMAGE_REVISION
+          required: true
+          default_value: '1'
+        - name: UPDATE_LATEST_TAG
+          required: true
+        - name: PACKAGING_BUILD_NUMBER
+          required: true
+        - name: PROMOTE_OS_TYPE
+          required: true
+          options:
+            - 'deb'
+            - 'ubi'
+code_artifact:
+  enable: true
+  package_paths:
+    - maven-snapshots/maven/io.confluent/control-center-images-next-gen
+    - maven-snapshots/maven/io.confluent/control-center-images-parent-next-gen
+    - maven-snapshots/maven/io.confluent.control-center-images/control-center-images-parent-next-gen
+    - maven-snapshots/maven/io.confluent.control-center-images/cp-enterprise-control-center-next-gen


### PR DESCRIPTION
This PR

1. Fixing Prometheus and Alertmanager dockerfile code, where move command was incorrect
2. adds pom.xml for alertmanager and prometheus which is used by mvn docker utility for building docker images
3. adds service.yml for the repo
4. Added "-next-gen" suffix to all output from this repo, so that we do not get conflicts with the previous repo.