### PR TITLE
Using the arch.type that is provided by generated semaphore.yml

### DIFF
--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -80,7 +80,7 @@ LABEL io.confluent.docker.git.repo="confluentinc/control-center-images"
 
 
 RUN mkdir /etc/alertmanager && \
-    mkdir /bin/alertmanager \
+    mkdir /bin/alertmanager
 
 # Remove the leading dot from the ARCH variable
 RUN ARCH_CLEANED=${ARCH#.} && \

--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -80,9 +80,14 @@ LABEL io.confluent.docker.git.repo="confluentinc/control-center-images"
 
 
 RUN mkdir /etc/alertmanager && \
-    mkdir /bin/alertmanager
+    mkdir /bin/alertmanager \
 
-COPY --from=builder /usr/libexec/confluent-control-center/linux_$ARCH/alertmanager/ /bin/alertmanager
+# Remove the leading dot from the ARCH variable
+RUN ARCH_CLEANED=${ARCH#.} && \
+    echo "Cleaned ARCH: $ARCH_CLEANED"
+
+# Use the cleaned ARCH variable in subsequent commands
+COPY --from=builder /usr/libexec/confluent-control-center/linux_$ARCH_CLEANED/alertmanager/ /bin/alertmanager
 COPY --from=builder /etc/confluent-control-center/alertmanager-generated.yml /etc/alertmanager/alertmanager-generated.yml
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
                 <configuration>
                     <buildArgs>
                         <UBI_MINIMAL_VERSION>${ubi9.minimal.image.version}</UBI_MINIMAL_VERSION>
-                        <ARCH>${arch}</ARCH>
+                        <ARCH>${arch.type}</ARCH>
                     </buildArgs>
                 </configuration>
             </plugin>
@@ -55,8 +55,9 @@
     <properties>
         <component.name>control-center</component.name>
         <io.confluent.control-center-images.version>8.0.0-0</io.confluent.control-center-images.version>
-        <arch>arm64</arch>
-        <!--  This is a placeholder for the architecture of the image that we will need from input -->
+        <arch.type>.arm64</arch.type>
+        <!--  This is a placeholder for the architecture of the image that we will need from input
+         and the input will come in mvn command from semaphore.yml file -->
         <docker.file>Dockerfile.ubi9</docker.file>
     </properties>
 </project>

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -82,7 +82,11 @@ LABEL io.confluent.docker.git.repo="confluentinc/control-center-images"
 RUN mkdir /etc/prometheus && \
     mkdir /bin/prometheus
 
-COPY --from=builder /usr/libexec/confluent-control-center/linux_$ARCH/prometheus/ /bin/prometheus
+# Remove the leading dot from the ARCH variable
+RUN ARCH_CLEANED=${ARCH#.} && \
+    echo "Cleaned ARCH: $ARCH_CLEANED" \
+
+COPY --from=builder /usr/libexec/confluent-control-center/linux_$ARCH_CLEANED/prometheus/ /bin/prometheus
 COPY --from=builder /etc/confluent-control-center/prometheus-generated.yml /etc/prometheus/prometheus-generated.yml
 COPY --from=builder /etc/confluent-control-center/trigger_rules-generated.yml /etc/prometheus/
 COPY --from=builder /etc/confluent-control-center/recording_rules-generated.yml /etc/prometheus/


### PR DESCRIPTION
The automatic generated semaphore.yml file has an `arch.type` whose value is `.amd64` or `.arm64`
```
  mvn -Dmaven.wagon.http.retryHandler.count=3 --batch-mode -P jenkins,docker clean package dependency:analyze validate -U -Ddocker.registry=$DOCKER_DEV_REGISTRY -Ddocker.upstream-registry=$DOCKER_UPSTREAM_REGISTRY
  -DBUILD_NUMBER=$BUILD_NUMBER -DGIT_COMMIT=$GIT_COMMIT -Ddocker.tag=$DOCKER_DEV_TAG$OS_TAG$AMD_ARCH -Ddocker.upstream-tag=$DOCKER_UPSTREAM_TAG$OS_TAG -Darch.type=$AMD_ARCH -Ddocker.os_type=ubi8
  $PACKAGING_BUILD_ARGS
```
Previously I was planning to send an environment variable by editing the semaphore.yml and using a different variable which doesn't have `.` in the prefix.
But since semaphore.yml cannot be edited, and it will be autogenerated.
We will need to take the arch.type with `.` in the input, and remove the dot in our dockerfile. 
