### PR TITLE
setting the project version property correctly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 
     <properties>
         <component.name>control-center</component.name>
-        <io.confluent.control-center-images.version>8.0.0-0</io.confluent.control-center-images.version>
+        <io.confluent.control-center-next-gen-images.version>8.0.0-0</io.confluent.control-center-next-gen-images.version>
         <arch.type>.arm64</arch.type>
         <!--  This is a placeholder for the architecture of the image that we will need from input
          and the input will come in mvn command from semaphore.yml file -->


### PR DESCRIPTION
In every maven based project, release-tools expect to have a property `<io.confluent.<repo-name>.version>`. While migration from control-center-images repo to this new repo, migration of this property correctly was missed. This PR fixes that.