### PR TITLE
Adding script files in Prometheus and Alert Manager

### DIFF
--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -80,6 +80,8 @@ RUN mkdir /etc/alertmanager && \
 # Use the cleaned ARCH variable in subsequent commands
 COPY --from=builder /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/ /bin/alertmanager
 COPY --from=builder /etc/confluent-control-center/alertmanager-generated.yml /etc/alertmanager/alertmanager-generated.yml
+COPY --from=builder /usr/bin/alertmanager-start /usr/bin/alertmanager-start
+COPY --from=builder /usr/bin/alertmanager-stop /usr/bin/alertmanager-stop
 
 
 RUN for file in /bin/alertmanager/alertmanager*; do mv "$file" /bin/alertmanager/alertmanager; done

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -80,6 +80,8 @@ COPY --from=builder /usr/libexec/confluent-control-center/linux_${ARCH#.}/promet
 COPY --from=builder /etc/confluent-control-center/prometheus-generated.yml /etc/prometheus/prometheus-generated.yml
 COPY --from=builder /etc/confluent-control-center/trigger_rules-generated.yml /etc/prometheus/
 COPY --from=builder /etc/confluent-control-center/recording_rules-generated.yml /etc/prometheus/
+COPY --from=builder /usr/bin/prometheus-start /usr/bin/prometheus-start
+COPY --from=builder /usr/bin/prometheus-stop /usr/bin/prometheus-stop
 
 RUN for file in /bin/prometheus/prometheus*; do mv "$file" /bin/prometheus/prometheus; done
 


### PR DESCRIPTION
Tested by cloning the semaphore generated images.
## Alert Manager Test
```
➜  ~ docker run --entrypoint /bin/bash -it 519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/dev/confluentinc/cp-enterprise-alertmanager:dev-master-0501fbc4-ubi9.arm64
bash-5.1$ cat /usr/bin/alertmanager-start
#!/usr/bin/bash
...
```
<img width="1257" alt="Screenshot 2025-04-07 at 2 41 30 PM" src="https://github.com/user-attachments/assets/cf356d54-5365-4efc-826b-7325b543df4f" />

## Prometheus Test
```
➜  ~ docker run --entrypoint  /bin/bash -it 519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/dev/confluentinc/cp-enterprise-prometheus:dev-master-0501fbc4-ubi9.arm64
bash-5.1$ ls /usr/bin
```
<img width="1257" alt="Screenshot 2025-04-07 at 2 42 54 PM" src="https://github.com/user-attachments/assets/62446be6-f223-40b7-9a8b-3d61415444d6" />

