### PR TITLE
[MMA-16549] adding changes for AM PM to fix path

### DIFF
--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -84,7 +84,7 @@ COPY --from=builder /usr/bin/alertmanager-stop /usr/bin/alertmanager-stop
 
 EXPOSE 9093
 
-RUN chmod +x /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager
+RUN chmod +x /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/alertmanager-${ARCH#.}
 WORKDIR /alertmanager
 
 

--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -100,7 +100,7 @@ RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
 ## Security Practice: Adheres to the principle of least privilege.
 RUN mkdir -p /var/lib/confluent/control-center/alertmanager/ && \
     mkdir -p /var/log/confluent/control-center && \
-    chown -R 1000:1000 /etc/confluent-control-center /var/lib/confluent/control-center/alertmanager/ /var/log/confluent/control-center
+    chown -R 1000:1000 /etc/confluent-control-center /var/lib/confluent/control-center/alertmanager/ /var/log/confluent/control-center /dev/stdout
 USER appuser
 
 VOLUME     [ "/var/lib/confluent/control-center/prometheus/data" ]

--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -85,20 +85,24 @@ COPY --from=builder /usr/bin/alertmanager-stop /usr/bin/alertmanager-stop
 EXPOSE 9093
 
 RUN chmod +x /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/alertmanager-${ARCH#.}
-WORKDIR /alertmanager
+WORKDIR /usr/bin
 
 
 RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
     mkdir -p /home/appuser && \
     chown 1000:1000 /home/appuser
 
-RUN chown -R 1000:1000 /etc/confluent-control-center /alertmanager
-USER appuser
-# Make the entrypoint script executable
 
-VOLUME     [ "/alertmanager" ]
-WORKDIR    /alertmanager
-ENTRYPOINT [ "/usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/alertmanager-${ARCH#.}" ]
-CMD        [ "--config.file=/etc/confluent-control-center/alertmanager-generated.yml", \
-             "--storage.path=/alertmanager" ]
+## Creating the default LOG Directory and data directory that we use in script so that when alertmanager
+## will run it can write data into it.
+## Limitation : Customer can't change the log and data path to some other directory, but they should be able to mount a volume and write on it.
+## Security Practice used: Principle of least privilege
+RUN mkdir -p /var/lib/confluent/control-center/alertmanager/ && \
+    mkdir -p /var/log/confluent/control-center && \
+    chown -R 1000:1000 /etc/confluent-control-center /var/lib/confluent/control-center/alertmanager/ /var/log/confluent/control-center
+USER appuser
+
+VOLUME     [ "/var/lib/confluent/control-center/prometheus/data" ]
+ENTRYPOINT [ "alertmanager-start" ]
+
 

--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -73,22 +73,18 @@ LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 LABEL io.confluent.docker.git.repo="confluentinc/control-center-images"
 
 
-RUN mkdir /etc/alertmanager && \
-    mkdir /bin/alertmanager
-
+RUN mkdir -p /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager && \
+    mkdir -p /etc/confluent-control-center
 
 # Use the cleaned ARCH variable in subsequent commands
-COPY --from=builder /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/ /bin/alertmanager
-COPY --from=builder /etc/confluent-control-center/alertmanager-generated.yml /etc/alertmanager/alertmanager-generated.yml
+COPY --from=builder /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/ /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/
+COPY --from=builder /etc/confluent-control-center/alertmanager-generated.yml /etc/confluent-control-center/alertmanager-generated.yml
 COPY --from=builder /usr/bin/alertmanager-start /usr/bin/alertmanager-start
 COPY --from=builder /usr/bin/alertmanager-stop /usr/bin/alertmanager-stop
 
-
-RUN for file in /bin/alertmanager/alertmanager*; do mv "$file" /bin/alertmanager/alertmanager; done
-
 EXPOSE 9093
 
-RUN chmod +x /bin/alertmanager/alertmanager
+RUN chmod +x /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager
 WORKDIR /alertmanager
 
 
@@ -96,13 +92,13 @@ RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
     mkdir -p /home/appuser && \
     chown 1000:1000 /home/appuser
 
-RUN chown -R 1000:1000 /etc/alertmanager /alertmanager
+RUN chown -R 1000:1000 /etc/confluent-control-center /alertmanager
 USER appuser
 # Make the entrypoint script executable
 
 VOLUME     [ "/alertmanager" ]
 WORKDIR    /alertmanager
-ENTRYPOINT [ "/bin/alertmanager/alertmanager" ]
-CMD        [ "--config.file=/etc/alertmanager/alertmanager-generated.yml", \
+ENTRYPOINT [ "/usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/alertmanager-${ARCH#.}" ]
+CMD        [ "--config.file=/etc/confluent-control-center/alertmanager-generated.yml", \
              "--storage.path=/alertmanager" ]
 

--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -78,7 +78,7 @@ RUN mkdir -p /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager 
 
 # Use the cleaned ARCH variable in subsequent commands
 COPY --from=builder /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/ /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/
-COPY --from=builder /etc/confluent-control-center/alertmanager-generated.yml /etc/confluent-control-center/alertmanager-generated.yml
+COPY --from=builder /etc/confluent-control-center/ /etc/confluent-control-center/
 COPY --from=builder /usr/bin/alertmanager-start /usr/bin/alertmanager-start
 COPY --from=builder /usr/bin/alertmanager-stop /usr/bin/alertmanager-stop
 

--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -93,10 +93,11 @@ RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
     chown 1000:1000 /home/appuser
 
 
-## Creating the default LOG Directory and data directory that we use in script so that when alertmanager
-## will run it can write data into it.
-## Limitation : Customer can't change the log and data path to some other directory, but they should be able to mount a volume and write on it.
-## Security Practice used: Principle of least privilege
+## Creating the default log directory and data directory utilized by the script to ensure that Alertmanager
+## can write data during its execution.
+## Limitation: Customers are restricted from changing the log and data paths to alternative directories; however,
+## they are permitted to mount a volume and write data to it.
+## Security Practice: Adheres to the principle of least privilege.
 RUN mkdir -p /var/lib/confluent/control-center/alertmanager/ && \
     mkdir -p /var/log/confluent/control-center && \
     chown -R 1000:1000 /etc/confluent-control-center /var/lib/confluent/control-center/alertmanager/ /var/log/confluent/control-center

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -97,9 +97,13 @@ RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
 
 ENV EXE_PATH="/usr/libexec/confluent-control-center"
 
-RUN mkdir -p /var/lib/confluent/control-center/prometheus/data
-RUN mkdir -p /var/log/confluent/control-center
-RUN chown -R 1000:1000 /etc/confluent-control-center /var/lib/confluent/control-center/prometheus/data /var/log/confluent/control-center
+## Creating the default LOG Directory and data directory that we use in script so that when alertmanager
+## will run it can write data into tit.
+## Limitation : Customer can't change the log and data path to some other directory, but they should be able to mount a volume and write on it.
+## Security Practice used: Principle of least privilege
+RUN mkdir -p /var/lib/confluent/control-center/prometheus/data && \
+    mkdir -p /var/log/confluent/control-center && \
+    chown -R 1000:1000 /etc/confluent-control-center /var/lib/confluent/control-center/prometheus/data /var/log/confluent/control-center
 
 USER appuser
 

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -102,7 +102,7 @@ ENV EXE_PATH="/usr/libexec/confluent-control-center"
 ## Security Practice: Adheres to the principle of least privilege.
 RUN mkdir -p /var/lib/confluent/control-center/prometheus/data && \
     mkdir -p /var/log/confluent/control-center && \
-    chown -R 1000:1000 /etc/confluent-control-center /var/lib/confluent/control-center/prometheus/data /var/log/confluent/control-center
+    chown -R 1000:1000 /etc/confluent-control-center /var/lib/confluent/control-center/prometheus/data /var/log/confluent/control-center /dev/stdout
 
 USER appuser
 

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -88,18 +88,19 @@ COPY --from=builder /usr/bin/prometheus-stop /usr/bin/prometheus-stop
 EXPOSE 9090
 
 RUN chmod +x /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/prometheus-${ARCH#.}
-WORKDIR /prometheus
+WORKDIR /usr/bin
 
 
 RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
     mkdir -p /home/appuser && \
     chown 1000:1000 /home/appuser
+
+RUN export EXE_PATH="/usr/libexec/confluent-control-center" && \
+    export LOG_PATH=/etc/confluent-control-center/logs
 #
-RUN chown -R 1000:1000 /etc/confluent-control-center /prometheus
+RUN chown -R 1000:1000 /etc/confluent-control-center /var/lib/confluent/control-center/prometheus/data
 USER appuser
 # Make the entrypoint script executable
 
-VOLUME     [ "/prometheus" ]
-ENTRYPOINT [ "/usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/prometheus-${ARCH#.}" ]
-CMD        [ "--config.file=/etc/confluent-control-center/prometheus-generated.yml", \
-             "--storage.tsdb.path=/prometheus" ]
+VOLUME     [ "/var/lib/confluent/control-center/prometheus/data" ]
+ENTRYPOINT [ "prometheus-start" ]

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -73,21 +73,21 @@ ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 LABEL io.confluent.docker.git.repo="confluentinc/control-center-images"
 
-RUN mkdir /etc/prometheus && \
-    mkdir /bin/prometheus
+RUN mkdir -p /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus && \
+    mkdir -p /etc/confluent-control-center
 
-COPY --from=builder /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/ /bin/prometheus/
-COPY --from=builder /etc/confluent-control-center/prometheus-generated.yml /etc/prometheus/prometheus-generated.yml
-COPY --from=builder /etc/confluent-control-center/trigger_rules-generated.yml /etc/prometheus/
-COPY --from=builder /etc/confluent-control-center/recording_rules-generated.yml /etc/prometheus/
+
+COPY --from=builder /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/ /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/
+COPY --from=builder /etc/confluent-control-center/prometheus-generated.yml /etc/confluent-control-center/prometheus-generated.yml
+COPY --from=builder /etc/confluent-control-center/trigger_rules-generated.yml /etc/confluent-control-center/
+COPY --from=builder /etc/confluent-control-center/recording_rules-generated.yml /etc/confluent-control-center/
 COPY --from=builder /usr/bin/prometheus-start /usr/bin/prometheus-start
 COPY --from=builder /usr/bin/prometheus-stop /usr/bin/prometheus-stop
 
-RUN for file in /bin/prometheus/prometheus*; do mv "$file" /bin/prometheus/prometheus; done
 
 EXPOSE 9090
 
-RUN chmod +x /bin/prometheus/prometheus
+RUN chmod +x /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus
 WORKDIR /prometheus
 
 
@@ -95,11 +95,11 @@ RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
     mkdir -p /home/appuser && \
     chown 1000:1000 /home/appuser
 #
-RUN chown -R 1000:1000 /etc/prometheus /prometheus
+RUN chown -R 1000:1000 /etc/confluent-control-center /prometheus
 USER appuser
 # Make the entrypoint script executable
 
 VOLUME     [ "/prometheus" ]
-ENTRYPOINT [ "/bin/prometheus/prometheus" ]
-CMD        [ "--config.file=/etc/prometheus/prometheus-generated.yml", \
+ENTRYPOINT [ "/usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/prometheus-${ARCH#.}" ]
+CMD        [ "--config.file=/etc/confluent-control-center/prometheus-generated.yml", \
              "--storage.tsdb.path=/prometheus" ]

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -97,7 +97,7 @@ RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
 
 ENV EXE_PATH="/usr/libexec/confluent-control-center"
 
-## Creating the default log directory and data directory utilized by the script to ensure that Alertmanager
+## Creating the default log directory and data directory utilized by the script to ensure that Prometheus
 ## can write data during its execution.
 ## Limitation: Customers are restricted from changing the log and data paths to alternative directories; however,
 ## they are permitted to mount a volume and write data to it.

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -95,12 +95,13 @@ RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
     mkdir -p /home/appuser && \
     chown 1000:1000 /home/appuser
 
-RUN export EXE_PATH="/usr/libexec/confluent-control-center" && \
-    export LOG_PATH=/etc/confluent-control-center/logs
-#
-RUN chown -R 1000:1000 /etc/confluent-control-center /var/lib/confluent/control-center/prometheus/data
+ENV EXE_PATH="/usr/libexec/confluent-control-center"
+
+RUN mkdir -p /var/lib/confluent/control-center/prometheus/data
+RUN mkdir -p /var/log/confluent/control-center
+RUN chown -R 1000:1000 /etc/confluent-control-center /var/lib/confluent/control-center/prometheus/data /var/log/confluent/control-center
+
 USER appuser
-# Make the entrypoint script executable
 
 VOLUME     [ "/var/lib/confluent/control-center/prometheus/data" ]
-ENTRYPOINT [ "prometheus-start" ]
+ENTRYPOINT ["prometheus-start"]

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -97,10 +97,11 @@ RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
 
 ENV EXE_PATH="/usr/libexec/confluent-control-center"
 
-## Creating the default LOG Directory and data directory that we use in script so that when alertmanager
-## will run it can write data into tit.
-## Limitation : Customer can't change the log and data path to some other directory, but they should be able to mount a volume and write on it.
-## Security Practice used: Principle of least privilege
+## Creating the default log directory and data directory utilized by the script to ensure that Alertmanager
+## can write data during its execution.
+## Limitation: Customers are restricted from changing the log and data paths to alternative directories; however,
+## they are permitted to mount a volume and write data to it.
+## Security Practice: Adheres to the principle of least privilege.
 RUN mkdir -p /var/lib/confluent/control-center/prometheus/data && \
     mkdir -p /var/log/confluent/control-center && \
     chown -R 1000:1000 /etc/confluent-control-center /var/lib/confluent/control-center/prometheus/data /var/log/confluent/control-center

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -87,7 +87,7 @@ COPY --from=builder /usr/bin/prometheus-stop /usr/bin/prometheus-stop
 
 EXPOSE 9090
 
-RUN chmod +x /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus
+RUN chmod +x /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/prometheus-${ARCH#.}
 WORKDIR /prometheus
 
 

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -78,9 +78,7 @@ RUN mkdir -p /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus &&
 
 
 COPY --from=builder /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/ /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/
-COPY --from=builder /etc/confluent-control-center/prometheus-generated.yml /etc/confluent-control-center/prometheus-generated.yml
-COPY --from=builder /etc/confluent-control-center/trigger_rules-generated.yml /etc/confluent-control-center/
-COPY --from=builder /etc/confluent-control-center/recording_rules-generated.yml /etc/confluent-control-center/
+COPY --from=builder /etc/confluent-control-center/ /etc/confluent-control-center/
 COPY --from=builder /usr/bin/prometheus-start /usr/bin/prometheus-start
 COPY --from=builder /usr/bin/prometheus-stop /usr/bin/prometheus-stop
 


### PR DESCRIPTION
This PR use script as a default way of starting Prometheus and Alertmanager There are following caveats that we should be aware about

#### Paths are now configurable in the script
We have made LOG_PATH, and other paths configurable in the script, but there's a security concept of "principle of least privilege" that we should not allow access to all the directories in our docker image. Same is done in opensource prometheus docker file as well. https://github.com/prometheus/prometheus/blob/main/Dockerfile. So, if the customer will change the LOG_PATH to anything custom, the prometheus won't start as prometheus won't have access to write on the path.

For more context:-
This command gives access to the final user i.e USER appuser to these directories, and the appuser will not have access to any other directory when prometheus is running in the docker image.
```
chown -R 1000:1000 /etc/confluent-control-center /var/lib/confluent/control-center/alertmanager/ /var/log/confluent/control-center
```

I believe if a customer is going to mount an external volume, and give that path. Then it should work. I'll perform one round of testing on this to verify the behaviour.
#### Using Script as default way of starting

Initially, to keep the prometheus docker image similar to the open source docker image, I kept their entrypoint and arguments similar. So that customers who are already familiar with the opensource prometheus image will find using our prometheus image very easy.
As the problems are increasing, I am thinking to use the script to start prometheus, instead of the previous approach even when nobody is overriding the entrypoint.
This way, I can keep the dockerfile clean, and the default way of running prometheus and alertmanager will be the same with how we want to use in CFK.