### PR TITLE
MMA-16691 (2.0.x): Fixing bug for wrong file usage in C3 Next Gen

### DIFF
--- a/control-center/include/etc/confluent/docker/configure
+++ b/control-center/include/etc/confluent/docker/configure
@@ -27,6 +27,6 @@ dub path "${CONTROL_CENTER_CONFIG_DIR}" writable
 echo "===> Check if ${CONTROL_CENTER_DATA_DIR} is writable ..."
 dub path "${CONTROL_CENTER_DATA_DIR}" writable
 
-dub template "/etc/confluent/docker/${OLD_COMPONENT_NAME}.properties.template" "${CONTROL_CENTER_CONFIG_DIR}/${COMPONENT}.properties"
+dub template "/etc/confluent/docker/${OLD_COMPONENT_NAME}.properties.template" "${CONTROL_CENTER_CONFIG_DIR}/${OLD_COMPONENT_NAME}.properties"
 dub template "/etc/confluent/docker/log4j.properties.template" "${CONTROL_CENTER_CONFIG_DIR}/log4j.properties"
 dub template "/etc/confluent/docker/admin.properties.template" "${CONTROL_CENTER_CONFIG_DIR}/admin.properties"

--- a/control-center/include/etc/confluent/docker/launch
+++ b/control-center/include/etc/confluent/docker/launch
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 echo "===> Launching ${COMPONENT} ... "
-exec "${OLD_COMPONENT_NAME}-start" "${CONTROL_CENTER_CONFIG_DIR}/${OLD_COMPONENT_NAME}.properties"
+exec "${OLD_COMPONENT_NAME}-start" "${CONTROL_CENTER_CONFIG_DIR}/${COMPONENT}.properties"

--- a/control-center/include/etc/confluent/docker/launch
+++ b/control-center/include/etc/confluent/docker/launch
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 echo "===> Launching ${COMPONENT} ... "
-exec "${OLD_COMPONENT_NAME}-start" "${CONTROL_CENTER_CONFIG_DIR}/${COMPONENT}.properties"
+exec "${OLD_COMPONENT_NAME}-start" "${CONTROL_CENTER_CONFIG_DIR}/${OLD_COMPONENT_NAME}.properties"


### PR DESCRIPTION
While updating the script as part of this PR https://github.com/confluentinc/control-center-next-gen-images/pull/7 
Two variables were used 
`OLD_COMPONENT_NAME` and `COMPONENT` where
```
COMPONENT=control-center-next-gen
OLD_COMPONENT_NAME=control-center
```

In the configure script, the `COMPONENT` variable is used to update the configs
but while in run script `OLD_COMPONENT_NAME` is used.

Which basically means that we are not using the file in which the configs are updated, this PR fixes the issue.

### Test

control-center-next-gen.properties contains the correct updated boostrap server from the environment variable.

```
[appuser@control-center confluent-control-center]$ cat control-center-next-gen.properties | grep bootst
bootstrap.servers=broker:29092
[appuser@control-center confluent-control-center]$ cat control-center.properties | grep bootst
#bootstrap.servers=kafka1:9092
```