### PR TITLE
CPBR-2597: Hardcoding ubi8 latest minimal tag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                 <configuration>
                     <buildArgs>
-                        <UBI_MINIMAL_VERSION>${ubi.image.version}</UBI_MINIMAL_VERSION>
+                        <UBI_MINIMAL_VERSION>8.10-1255</UBI_MINIMAL_VERSION>
                         <ARCH>${arch.type}</ARCH>
                       <C3_VERSION>${C3_VERSION}</C3_VERSION>
                     </buildArgs>
@@ -58,7 +58,7 @@
                 <image>
                   <build>
                     <args>
-                      <UBI_MINIMAL_VERSION>${ubi.image.version}</UBI_MINIMAL_VERSION>
+                      <UBI_MINIMAL_VERSION>8.10-1255</UBI_MINIMAL_VERSION>
                       <ARCH>${arch.type}</ARCH>
                       <C3_VERSION>${C3_VERSION}</C3_VERSION>
                       <CONFLUENT_VERSION>${C3_VERSION}</CONFLUENT_VERSION>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                 <configuration>
                     <buildArgs>
-                        <UBI_MINIMAL_VERSION>8.10-1255</UBI_MINIMAL_VERSION>
+                        <UBI_MINIMAL_VERSION>8.10-1179.1741863533</UBI_MINIMAL_VERSION>
                         <ARCH>${arch.type}</ARCH>
                       <C3_VERSION>${C3_VERSION}</C3_VERSION>
                     </buildArgs>
@@ -58,7 +58,7 @@
                 <image>
                   <build>
                     <args>
-                      <UBI_MINIMAL_VERSION>8.10-1255</UBI_MINIMAL_VERSION>
+                      <UBI_MINIMAL_VERSION>8.10-1179.1741863533</UBI_MINIMAL_VERSION>
                       <ARCH>${arch.type}</ARCH>
                       <C3_VERSION>${C3_VERSION}</C3_VERSION>
                       <CONFLUENT_VERSION>${C3_VERSION}</CONFLUENT_VERSION>


### PR DESCRIPTION
control-center-next-gen 2.1.0 release will be dependent on CP 7.9. To make sure latest base OS image is used, manually updating the base OS image tag to latest ubi8 minimal tag at https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8. This will make sure prometheus and alertmanager will get latest ubi8 minimal tag

For control-center-next-gen image, it will be based on 7.9.1 RC based cp-base-new image which will be based on latest ubi8 minimal tag at that time.