### PR TITLE
[MMA-16829] - fix labels and add license file for Alertmanager and Prometheus Images

### DIFF
--- a/alertmanager/Dockerfile.ubi8
+++ b/alertmanager/Dockerfile.ubi8
@@ -57,6 +57,10 @@ WORKDIR /app
 USER root
 
 ARG ARCH
+ARG PROJECT_VERSION
+ARG ARTIFACT_ID
+ARG GIT_COMMIT
+
 # Update package list and install essential packages
 
 LABEL maintainer="partner-support@confluent.io"
@@ -81,7 +85,7 @@ COPY --from=builder /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertm
 COPY --from=builder /etc/confluent-control-center/ /etc/confluent-control-center/
 COPY --from=builder /usr/bin/alertmanager-start /usr/bin/alertmanager-start
 COPY --from=builder /usr/bin/alertmanager-stop /usr/bin/alertmanager-stop
-
+COPY --from=builder /licenses /licenses
 EXPOSE 9093
 
 RUN chmod +x /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/alertmanager-${ARCH#.}

--- a/prometheus/Dockerfile.ubi8
+++ b/prometheus/Dockerfile.ubi8
@@ -58,6 +58,10 @@ WORKDIR /app
 USER root
 
 ARG ARCH
+ARG PROJECT_VERSION
+ARG ARTIFACT_ID
+ARG GIT_COMMIT
+
 # Update package list and install essential packages
 
 LABEL maintainer="partner-support@confluent.io"
@@ -81,6 +85,7 @@ COPY --from=builder /usr/libexec/confluent-control-center/linux_${ARCH#.}/promet
 COPY --from=builder /etc/confluent-control-center/ /etc/confluent-control-center/
 COPY --from=builder /usr/bin/prometheus-start /usr/bin/prometheus-start
 COPY --from=builder /usr/bin/prometheus-stop /usr/bin/prometheus-stop
+COPY --from=builder /licenses /licenses
 
 
 EXPOSE 9090


### PR DESCRIPTION
**JIRA** - https://confluentinc.atlassian.net/browse/MMA-16829

We were getting Redhat certification errors due to missing labels and certificates.

**Testing**
1. Missing labels are available now
<img width="641" alt="image" src="https://github.com/user-attachments/assets/ef99fd97-8001-4228-a170-c812e210b8ce" />

2. License Verification
<img width="665" alt="image" src="https://github.com/user-attachments/assets/d4a45748-c15a-4277-9d7e-1632559a3d6f" />

