### PR TITLE
CPBR-2552: Commeting control-center-next-gen image promotion from cp_dockerfile_promote yaml file

### DIFF
--- a/.semaphore/cp_dockerfile_promote.yml
+++ b/.semaphore/cp_dockerfile_promote.yml
@@ -63,37 +63,37 @@ blocks:
     dependencies: []
     task:
       jobs:
-        - name: Promote confluentinc/cp-enterprise-control-center-next-gen ubi8 AMD
-          env_vars:
-            - name: DOCKER_IMAGE
-              value: confluentinc/cp-enterprise-control-center-next-gen
-          commands:
-            - export OS_TYPE="ubi8"
-            - export DOCKER_REPO="confluentinc/cp-enterprise-control-center-next-gen"
-            - if [[ ! "$OS_TYPE" ]]; then export OS_TAG=""; elif [[ "$OS_TYPE" =~ $PROMOTE_OS_TYPE* ]]; then export OS_TAG="-$OS_TYPE"; fi
-            - export INTERNAL_IMAGE_TAG="$BRANCH_TAG-$PACKAGING_BUILD_NUMBER$OS_TAG$AMD_ARCH"
-            - export PROMOTED_TAG="$PROMOTED_TAG_PREFIX$OS_TAG$AMD_ARCH"
-            - docker pull $DOCKER_PROD_REGISTRY$DOCKER_REPO:$INTERNAL_IMAGE_TAG
-            - docker tag $DOCKER_PROD_REGISTRY$DOCKER_REPO:$INTERNAL_IMAGE_TAG $DOCKER_REPO:$PROMOTED_TAG
-            - docker run --rm $DOCKER_REPO:$PROMOTED_TAG sh -c "grep staging /etc/yum.repos.d/confluent.repo || grep staging /etc/apt/sources.list" || export STAGING_CHECK_SUCCEED="true"
-            - if [[ ! "$STAGING_CHECK_SUCCEED" ]]; then echo "Detected there was a staging repo in image $DOCKER_REPO:$PROMOTED_TAG refusing to promote." && exit 1; fi
-            - docker push $DOCKER_REPO:$PROMOTED_TAG
-            - >-
-              if [[ ! "$OS_TYPE" ]] || [[ "$OS_TYPE" =~ ubi* ]]; then
-                  export APPLY_TAG=$C3_VERSION$AMD_ARCH
-                  docker tag $DOCKER_PROD_REGISTRY$DOCKER_REPO:$INTERNAL_IMAGE_TAG $DOCKER_REPO:$APPLY_TAG
-                  docker push $DOCKER_REPO:$APPLY_TAG
-                  export APPLIED="true"
-              fi
-            - >-
-              if [[ $UPDATE_LATEST_TAG == "True" ]]; then
-                  if [[ $APPLIED ]]; then
-                  docker tag $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:latest$AMD_ARCH
-                  docker push $DOCKER_REPO:latest$AMD_ARCH
-                  fi
-                  docker tag $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:latest-$OS_TYPE$AMD_ARCH
-                  docker push $DOCKER_REPO:latest-$OS_TYPE$AMD_ARCH
-              fi
+#        - name: Promote confluentinc/cp-enterprise-control-center-next-gen ubi8 AMD
+#          env_vars:
+#            - name: DOCKER_IMAGE
+#              value: confluentinc/cp-enterprise-control-center-next-gen
+#          commands:
+#            - export OS_TYPE="ubi8"
+#            - export DOCKER_REPO="confluentinc/cp-enterprise-control-center-next-gen"
+#            - if [[ ! "$OS_TYPE" ]]; then export OS_TAG=""; elif [[ "$OS_TYPE" =~ $PROMOTE_OS_TYPE* ]]; then export OS_TAG="-$OS_TYPE"; fi
+#            - export INTERNAL_IMAGE_TAG="$BRANCH_TAG-$PACKAGING_BUILD_NUMBER$OS_TAG$AMD_ARCH"
+#            - export PROMOTED_TAG="$PROMOTED_TAG_PREFIX$OS_TAG$AMD_ARCH"
+#            - docker pull $DOCKER_PROD_REGISTRY$DOCKER_REPO:$INTERNAL_IMAGE_TAG
+#            - docker tag $DOCKER_PROD_REGISTRY$DOCKER_REPO:$INTERNAL_IMAGE_TAG $DOCKER_REPO:$PROMOTED_TAG
+#            - docker run --rm $DOCKER_REPO:$PROMOTED_TAG sh -c "grep staging /etc/yum.repos.d/confluent.repo || grep staging /etc/apt/sources.list" || export STAGING_CHECK_SUCCEED="true"
+#            - if [[ ! "$STAGING_CHECK_SUCCEED" ]]; then echo "Detected there was a staging repo in image $DOCKER_REPO:$PROMOTED_TAG refusing to promote." && exit 1; fi
+#            - docker push $DOCKER_REPO:$PROMOTED_TAG
+#            - >-
+#              if [[ ! "$OS_TYPE" ]] || [[ "$OS_TYPE" =~ ubi* ]]; then
+#                  export APPLY_TAG=$C3_VERSION$AMD_ARCH
+#                  docker tag $DOCKER_PROD_REGISTRY$DOCKER_REPO:$INTERNAL_IMAGE_TAG $DOCKER_REPO:$APPLY_TAG
+#                  docker push $DOCKER_REPO:$APPLY_TAG
+#                  export APPLIED="true"
+#              fi
+#            - >-
+#              if [[ $UPDATE_LATEST_TAG == "True" ]]; then
+#                  if [[ $APPLIED ]]; then
+#                  docker tag $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:latest$AMD_ARCH
+#                  docker push $DOCKER_REPO:latest$AMD_ARCH
+#                  fi
+#                  docker tag $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:latest-$OS_TYPE$AMD_ARCH
+#                  docker push $DOCKER_REPO:latest-$OS_TYPE$AMD_ARCH
+#              fi
         - name: Promote confluentinc/cp-enterprise-prometheus ubi8 AMD
           env_vars:
             - name: DOCKER_IMAGE
@@ -160,37 +160,37 @@ blocks:
     dependencies: []
     task:
       jobs:
-        - name: Promote confluentinc/cp-enterprise-control-center-next-gen ubi8 ARM
-          env_vars:
-            - name: DOCKER_IMAGE
-              value: confluentinc/cp-enterprise-control-center-next-gen
-          commands:
-            - export OS_TYPE="ubi8"
-            - export DOCKER_REPO="confluentinc/cp-enterprise-control-center-next-gen"
-            - if [[ ! "$OS_TYPE" ]]; then export OS_TAG=""; elif [[ "$OS_TYPE" =~ $PROMOTE_OS_TYPE* ]]; then export OS_TAG="-$OS_TYPE"; fi
-            - export INTERNAL_IMAGE_TAG="$BRANCH_TAG-$PACKAGING_BUILD_NUMBER$OS_TAG$ARM_ARCH"
-            - export PROMOTED_TAG="$PROMOTED_TAG_PREFIX$OS_TAG$ARM_ARCH"
-            - docker pull $DOCKER_PROD_REGISTRY$DOCKER_REPO:$INTERNAL_IMAGE_TAG
-            - docker tag $DOCKER_PROD_REGISTRY$DOCKER_REPO:$INTERNAL_IMAGE_TAG $DOCKER_REPO:$PROMOTED_TAG
-            - docker run --rm $DOCKER_REPO:$PROMOTED_TAG sh -c "grep staging /etc/yum.repos.d/confluent.repo || grep staging /etc/apt/sources.list" || export STAGING_CHECK_SUCCEED="true"
-            - if [[ ! "$STAGING_CHECK_SUCCEED" ]]; then echo "Detected there was a staging repo in image $DOCKER_REPO:$PROMOTED_TAG refusing to promote." && exit 1; fi
-            - docker push $DOCKER_REPO:$PROMOTED_TAG
-            - >-
-              if [[ ! "$OS_TYPE" ]] || [[ "$OS_TYPE" =~ ubi* ]]; then
-                  export APPLY_TAG=$C3_VERSION$ARM_ARCH
-                  docker tag $DOCKER_PROD_REGISTRY$DOCKER_REPO:$INTERNAL_IMAGE_TAG $DOCKER_REPO:$APPLY_TAG
-                  docker push $DOCKER_REPO:$APPLY_TAG
-                  export APPLIED="true"
-              fi
-            - >-
-              if [[ $UPDATE_LATEST_TAG == "True" ]]; then
-                  if [[ $APPLIED ]]; then
-                  docker tag $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:latest$ARM_ARCH
-                  docker push $DOCKER_REPO:latest$ARM_ARCH
-                  fi
-                  docker tag $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:latest-$OS_TYPE$ARM_ARCH
-                  docker push $DOCKER_REPO:latest-$OS_TYPE$ARM_ARCH
-              fi
+#        - name: Promote confluentinc/cp-enterprise-control-center-next-gen ubi8 ARM
+#          env_vars:
+#            - name: DOCKER_IMAGE
+#              value: confluentinc/cp-enterprise-control-center-next-gen
+#          commands:
+#            - export OS_TYPE="ubi8"
+#            - export DOCKER_REPO="confluentinc/cp-enterprise-control-center-next-gen"
+#            - if [[ ! "$OS_TYPE" ]]; then export OS_TAG=""; elif [[ "$OS_TYPE" =~ $PROMOTE_OS_TYPE* ]]; then export OS_TAG="-$OS_TYPE"; fi
+#            - export INTERNAL_IMAGE_TAG="$BRANCH_TAG-$PACKAGING_BUILD_NUMBER$OS_TAG$ARM_ARCH"
+#            - export PROMOTED_TAG="$PROMOTED_TAG_PREFIX$OS_TAG$ARM_ARCH"
+#            - docker pull $DOCKER_PROD_REGISTRY$DOCKER_REPO:$INTERNAL_IMAGE_TAG
+#            - docker tag $DOCKER_PROD_REGISTRY$DOCKER_REPO:$INTERNAL_IMAGE_TAG $DOCKER_REPO:$PROMOTED_TAG
+#            - docker run --rm $DOCKER_REPO:$PROMOTED_TAG sh -c "grep staging /etc/yum.repos.d/confluent.repo || grep staging /etc/apt/sources.list" || export STAGING_CHECK_SUCCEED="true"
+#            - if [[ ! "$STAGING_CHECK_SUCCEED" ]]; then echo "Detected there was a staging repo in image $DOCKER_REPO:$PROMOTED_TAG refusing to promote." && exit 1; fi
+#            - docker push $DOCKER_REPO:$PROMOTED_TAG
+#            - >-
+#              if [[ ! "$OS_TYPE" ]] || [[ "$OS_TYPE" =~ ubi* ]]; then
+#                  export APPLY_TAG=$C3_VERSION$ARM_ARCH
+#                  docker tag $DOCKER_PROD_REGISTRY$DOCKER_REPO:$INTERNAL_IMAGE_TAG $DOCKER_REPO:$APPLY_TAG
+#                  docker push $DOCKER_REPO:$APPLY_TAG
+#                  export APPLIED="true"
+#              fi
+#            - >-
+#              if [[ $UPDATE_LATEST_TAG == "True" ]]; then
+#                  if [[ $APPLIED ]]; then
+#                  docker tag $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:latest$ARM_ARCH
+#                  docker push $DOCKER_REPO:latest$ARM_ARCH
+#                  fi
+#                  docker tag $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:latest-$OS_TYPE$ARM_ARCH
+#                  docker push $DOCKER_REPO:latest-$OS_TYPE$ARM_ARCH
+#              fi
         - name: Promote confluentinc/cp-enterprise-prometheus ubi8 ARM
           env_vars:
             - name: DOCKER_IMAGE
@@ -257,32 +257,32 @@ blocks:
     dependencies: ["Promote AMD", "Promote ARM"]
     task:
       jobs:
-        - name: Create Manifest confluentinc/cp-enterprise-control-center-next-gen ubi8
-          env_vars:
-            - name: DOCKER_IMAGE
-              value: confluentinc/cp-enterprise-control-center-next-gen
-          commands:
-            - export OS_TYPE="ubi8"
-            - if [[ ! "$OS_TYPE" ]]; then export OS_TAG=""; elif [[ "$OS_TYPE" =~ $PROMOTE_OS_TYPE* ]]; then export OS_TAG="-$OS_TYPE"; fi
-            - export DOCKER_REPO="confluentinc/cp-enterprise-control-center-next-gen"
-            - export PROMOTED_TAG="$PROMOTED_TAG_PREFIX$OS_TAG"
-            - docker manifest create $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:$PROMOTED_TAG$AMD_ARCH $DOCKER_REPO:$PROMOTED_TAG$ARM_ARCH
-            - docker manifest push $DOCKER_REPO:$PROMOTED_TAG
-            - >-
-              if [[ ! "$OS_TYPE" ]] || [[ "$OS_TYPE" =~ ubi* ]]; then
-                  docker manifest create $DOCKER_REPO:$C3_VERSION $DOCKER_REPO:$C3_VERSION$AMD_ARCH $DOCKER_REPO:$C3_VERSION$ARM_ARCH
-                  docker manifest push $DOCKER_REPO:$C3_VERSION
-                  export APPLIED="true"
-              fi
-            - >-
-              if [[ $UPDATE_LATEST_TAG == "True" ]]; then
-                  if [[ $APPLIED ]]; then
-                  docker manifest create $DOCKER_REPO:latest $DOCKER_REPO:latest$AMD_ARCH $DOCKER_REPO:latest$ARM_ARCH
-                  docker manifest push $DOCKER_REPO:latest
-                  fi
-                  docker manifest create $DOCKER_REPO:latest-$OS_TYPE $DOCKER_REPO:latest-$OS_TYPE$AMD_ARCH $DOCKER_REPO:latest-$OS_TYPE$ARM_ARCH
-                  docker manifest push $DOCKER_REPO:latest-$OS_TYPE
-              fi
+#        - name: Create Manifest confluentinc/cp-enterprise-control-center-next-gen ubi8
+#          env_vars:
+#            - name: DOCKER_IMAGE
+#              value: confluentinc/cp-enterprise-control-center-next-gen
+#          commands:
+#            - export OS_TYPE="ubi8"
+#            - if [[ ! "$OS_TYPE" ]]; then export OS_TAG=""; elif [[ "$OS_TYPE" =~ $PROMOTE_OS_TYPE* ]]; then export OS_TAG="-$OS_TYPE"; fi
+#            - export DOCKER_REPO="confluentinc/cp-enterprise-control-center-next-gen"
+#            - export PROMOTED_TAG="$PROMOTED_TAG_PREFIX$OS_TAG"
+#            - docker manifest create $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:$PROMOTED_TAG$AMD_ARCH $DOCKER_REPO:$PROMOTED_TAG$ARM_ARCH
+#            - docker manifest push $DOCKER_REPO:$PROMOTED_TAG
+#            - >-
+#              if [[ ! "$OS_TYPE" ]] || [[ "$OS_TYPE" =~ ubi* ]]; then
+#                  docker manifest create $DOCKER_REPO:$C3_VERSION $DOCKER_REPO:$C3_VERSION$AMD_ARCH $DOCKER_REPO:$C3_VERSION$ARM_ARCH
+#                  docker manifest push $DOCKER_REPO:$C3_VERSION
+#                  export APPLIED="true"
+#              fi
+#            - >-
+#              if [[ $UPDATE_LATEST_TAG == "True" ]]; then
+#                  if [[ $APPLIED ]]; then
+#                  docker manifest create $DOCKER_REPO:latest $DOCKER_REPO:latest$AMD_ARCH $DOCKER_REPO:latest$ARM_ARCH
+#                  docker manifest push $DOCKER_REPO:latest
+#                  fi
+#                  docker manifest create $DOCKER_REPO:latest-$OS_TYPE $DOCKER_REPO:latest-$OS_TYPE$AMD_ARCH $DOCKER_REPO:latest-$OS_TYPE$ARM_ARCH
+#                  docker manifest push $DOCKER_REPO:latest-$OS_TYPE
+#              fi
         - name: Create Manifest confluentinc/cp-enterprise-prometheus ubi8
           env_vars:
             - name: DOCKER_IMAGE


### PR DESCRIPTION
As part of https://confluentinc.atlassian.net/browse/CPBR-2552, we are trying to certify c3++ 2.0.0 release docker images as part of redhat certification. 
Slack thread: https://confluent.slack.com/archives/C07648S1FMX/p1747393422956229?thread_ts=1747376164.839559&cid=C07648S1FMX
However, Redhat certification is failing for Prometheus and Alertmanager docker images, and is passing for control-center-next-gen docker image.
The failures are the same for both images:

- Missing licensing information at /licenses
- Missing required labels in the Dockerfile


There will be another PR raised to fix these issues into the 2.0.0-rc250429105958 branch. Post this, we will rebuild all RC images for all 3 components (c3, prometheus, alert manager).

Finally we will override the previously released images for prometheus and alert manager only in docker hub. This PR comments out the control-center-next-gen promotion steps so that only prometheus and alert manager docker images are repromoted to dockerhub.