### PR TITLE
CPBR-2664: Push docker tags summary file to semaphore ci artifacts for docker builds

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -403,8 +403,8 @@ blocks:
   - name: Push docker images tags summary to artifacts
     dependencies:
       - Create Manifest and Maven Deploy
-    # run:
-    #   when: "branch = 'master' or branch =~ '^[0-9]+\\.[0-9]+\\.x$' or branch =~ '^[0-9]+\\.[0-9]+\\.[0-9]+(-cp[0-9]+)?(-rc[0-9]+)?$'"
+    run:
+      when: "branch = 'master' or branch =~ '^[0-9]+\\.[0-9]+\\.x$' or branch =~ '^[0-9]+\\.[0-9]+\\.[0-9]+(-cp[0-9]+)?(-rc[0-9]+)?$'"
     task:
       jobs:
         - name: Push docker images tags summary to artifacts

--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -373,14 +373,14 @@ blocks:
       jobs:
         - name: Create Manifest and Maven Deploy
           commands:
-            - export DOCKER_PROD_IMAGE_NAME=$DOCKER_PROD_REGISTRY${DOCKER_REPOS// / $DOCKER_PROD_REGISTRY}
+            - export DOCKER_PROD_IMAGE_NAMES=$DOCKER_PROD_REGISTRY${DOCKER_REPOS// / $DOCKER_PROD_REGISTRY}
             - |-
               if [[ ! $IS_RELEASE && ! $IS_PREVIEW ]]; then
                 echo "maven deploy command"
               fi
             # Create manifest
             - >-
-              for image in $DOCKER_PROD_IMAGE_NAME;
+              for image in $DOCKER_PROD_IMAGE_NAMES;
               do
                 export OS_TAG="-ubi8"
                 export GIT_TAG=$GIT_COMMIT$OS_TAG
@@ -410,7 +410,8 @@ blocks:
         - name: Create Manifest and Maven Deploy
           commands:
             - export DOCKER_PROD_IMAGE_NAMES=$DOCKER_PROD_REGISTRY${DOCKER_REPOS// / $DOCKER_PROD_REGISTRY}
-            - echo "The following tags are available for this build:"
+            - export OS_TAG="-ubi8"
+            - echo "The following tags are available for this build:" > docker-tags-summary.txt
             - >-
               for image in $DOCKER_PROD_IMAGE_NAMES;
               do
@@ -418,6 +419,7 @@ blocks:
                 echo "$image:$BRANCH_TAG-$BUILD_NUMBER$OS_TAG" >> docker-tags-summary.txt
                 echo "$image:$BRANCH_TAG-$PACKAGING_BUILD_NUMBER$OS_TAG" >> docker-tags-summary.txt
                 echo "$image:$LATEST_TAG$OS_TAG" >> docker-tags-summary.txt
+                echo "" >> docker-tags-summary.txt
               done
             - echo "Tags summary saved to docker-tags-summary.txt"
             - artifact push workflow docker-tags-summary.txt

--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -373,14 +373,14 @@ blocks:
       jobs:
         - name: Create Manifest and Maven Deploy
           commands:
-            - export DOCKER_PROD_IMAGE_NAME=$DOCKER_PROD_REGISTRY${DOCKER_REPOS// / $DOCKER_PROD_REGISTRY}
+            - export DOCKER_PROD_IMAGE_NAMES=$DOCKER_PROD_REGISTRY${DOCKER_REPOS// / $DOCKER_PROD_REGISTRY}
             - |-
               if [[ ! $IS_RELEASE && ! $IS_PREVIEW ]]; then
                 echo "maven deploy command"
               fi
             # Create manifest
             - >-
-              for image in $DOCKER_PROD_IMAGE_NAME;
+              for image in $DOCKER_PROD_IMAGE_NAMES;
               do
                 export OS_TAG="-ubi8"
                 export GIT_TAG=$GIT_COMMIT$OS_TAG
@@ -400,6 +400,27 @@ blocks:
                 docker manifest create $image:$LATEST_MANIFEST_TAG $image:$LATEST_MANIFEST_TAG$AMD_ARCH $image:$LATEST_MANIFEST_TAG$ARM_ARCH
                 docker manifest push $image:$LATEST_MANIFEST_TAG
               done
+  - name: Push docker images tags summary to artifacts
+    dependencies:
+      - Create Manifest and Maven Deploy
+    # run:
+    #   when: "branch = 'master' or branch =~ '^[0-9]+\\.[0-9]+\\.x$' or branch =~ '^[0-9]+\\.[0-9]+\\.[0-9]+(-cp[0-9]+)?(-rc[0-9]+)?$'"
+    task:
+      jobs:
+        - name: Create Manifest and Maven Deploy
+          commands:
+            - export DOCKER_PROD_IMAGE_NAMES=$DOCKER_PROD_REGISTRY${DOCKER_REPOS// / $DOCKER_PROD_REGISTRY}
+            - echo "The following tags are available for this build:"
+            - >-
+              for image in $DOCKER_PROD_IMAGE_NAMES;
+              do
+                echo "$image:$GIT_COMMIT$OS_TAG" >> docker-tags-summary.txt
+                echo "$image:$BRANCH_TAG-$BUILD_NUMBER$OS_TAG" >> docker-tags-summary.txt
+                echo "$image:$BRANCH_TAG-$PACKAGING_BUILD_NUMBER$OS_TAG" >> docker-tags-summary.txt
+                echo "$image:$LATEST_TAG$OS_TAG" >> docker-tags-summary.txt
+              done
+            - echo "Tags summary saved to docker-tags-summary.txt"
+            - artifact push workflow docker-tags-summary.txt
 promotions:
   - name: 'Trigger APPSEC SBOM Generation Task'
     pipeline_file: trigger-sbom-generation.yml

--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -373,14 +373,14 @@ blocks:
       jobs:
         - name: Create Manifest and Maven Deploy
           commands:
-            - export DOCKER_PROD_IMAGE_NAMES=$DOCKER_PROD_REGISTRY${DOCKER_REPOS// / $DOCKER_PROD_REGISTRY}
+            - export DOCKER_PROD_IMAGE_NAME=$DOCKER_PROD_REGISTRY${DOCKER_REPOS// / $DOCKER_PROD_REGISTRY}
             - |-
               if [[ ! $IS_RELEASE && ! $IS_PREVIEW ]]; then
                 echo "maven deploy command"
               fi
             # Create manifest
             - >-
-              for image in $DOCKER_PROD_IMAGE_NAMES;
+              for image in $DOCKER_PROD_IMAGE_NAME;
               do
                 export OS_TAG="-ubi8"
                 export GIT_TAG=$GIT_COMMIT$OS_TAG

--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -402,12 +402,12 @@ blocks:
               done
   - name: Push docker images tags summary to artifacts
     dependencies:
-      - Push docker images tags summary to artifacts
+      - Create Manifest and Maven Deploy
     # run:
     #   when: "branch = 'master' or branch =~ '^[0-9]+\\.[0-9]+\\.x$' or branch =~ '^[0-9]+\\.[0-9]+\\.[0-9]+(-cp[0-9]+)?(-rc[0-9]+)?$'"
     task:
       jobs:
-        - name: Create Manifest and Maven Deploy
+        - name: Push docker images tags summary to artifacts
           commands:
             - export DOCKER_PROD_IMAGE_NAMES=$DOCKER_PROD_REGISTRY${DOCKER_REPOS// / $DOCKER_PROD_REGISTRY}
             - export OS_TAG="-ubi8"

--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -373,14 +373,14 @@ blocks:
       jobs:
         - name: Create Manifest and Maven Deploy
           commands:
-            - export DOCKER_PROD_IMAGE_NAMES=$DOCKER_PROD_REGISTRY${DOCKER_REPOS// / $DOCKER_PROD_REGISTRY}
+            - export DOCKER_PROD_IMAGE_NAME=$DOCKER_PROD_REGISTRY${DOCKER_REPOS// / $DOCKER_PROD_REGISTRY}
             - |-
               if [[ ! $IS_RELEASE && ! $IS_PREVIEW ]]; then
                 echo "maven deploy command"
               fi
             # Create manifest
             - >-
-              for image in $DOCKER_PROD_IMAGE_NAMES;
+              for image in $DOCKER_PROD_IMAGE_NAME;
               do
                 export OS_TAG="-ubi8"
                 export GIT_TAG=$GIT_COMMIT$OS_TAG
@@ -402,7 +402,7 @@ blocks:
               done
   - name: Push docker images tags summary to artifacts
     dependencies:
-      - Create Manifest and Maven Deploy
+      - Push docker images tags summary to artifacts
     # run:
     #   when: "branch = 'master' or branch =~ '^[0-9]+\\.[0-9]+\\.x$' or branch =~ '^[0-9]+\\.[0-9]+\\.[0-9]+(-cp[0-9]+)?(-rc[0-9]+)?$'"
     task:


### PR DESCRIPTION
This PR adds a new block to push the docker tags, for all images built as part of the docker build process, for nightly and rc workflows only.
These tags will be pushed as semaphore ci artifacts for ease of access.

Sample output file:
<img width="991" alt="image" src="https://github.com/user-attachments/assets/84cbb27c-dd23-4b8c-9777-d81e552abf8e" />
