### PR TITLE
CPBR-2664: : Change os tag to ubi9 for docker image tags summary from 2.2.x branch

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -410,7 +410,7 @@ blocks:
         - name: Push docker images tags summary to artifacts
           commands:
             - export DOCKER_PROD_IMAGE_NAMES=$DOCKER_PROD_REGISTRY${DOCKER_REPOS// / $DOCKER_PROD_REGISTRY}
-            - export OS_TAG="-ubi8"
+            - export OS_TAG="-ubi9"
             - echo "The following tags are available for this build:" > docker-tags-summary.txt
             - >-
               for image in $DOCKER_PROD_IMAGE_NAMES;


### PR DESCRIPTION
This PR is raised on top of https://github.com/confluentinc/control-center-next-gen-images/pull/31 and changes os tag to ubi9 for docker image tags summary from 2.2.x branch.
Images from 2.2.x onwards are built using ubi9 base images, hence this change.