### PR TITLE
Add missing -latest suffix for 2.2.0 RC1 docker upstream tag

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -78,7 +78,7 @@ global_job_config:
       - export DOCKER_PROD_REGISTRY="519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/prod/"
       - export DOCKER_UPSTREAM_REGISTRY=$DOCKER_PROD_REGISTRY
       - export LATEST_TAG=$BRANCH_TAG-latest
-      - export DOCKER_UPSTREAM_TAG="8.0.0-rc250530060959"
+      - export DOCKER_UPSTREAM_TAG="8.0.0-rc250530060959-latest"
       - export DOCKER_REPOS="confluentinc/cp-enterprise-control-center-next-gen confluentinc/cp-enterprise-prometheus confluentinc/cp-enterprise-alertmanager"
       - export COMMUNITY_DOCKER_REPOS=""
       - |

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -68,7 +68,7 @@ global_job_config:
       - export DOCKER_PROD_REGISTRY="519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/prod/"
       - export DOCKER_UPSTREAM_REGISTRY=$DOCKER_PROD_REGISTRY
       - export LATEST_TAG=$BRANCH_TAG-latest
-      - export DOCKER_UPSTREAM_TAG="8.0.0-rc250530060959"
+      - export DOCKER_UPSTREAM_TAG="8.0.0-rc250530060959-latest"
       - export DOCKER_REPOS="confluentinc/cp-enterprise-control-center-next-gen confluentinc/cp-enterprise-prometheus confluentinc/cp-enterprise-alertmanager"
       - export COMMUNITY_DOCKER_REPOS=""
       - |


### PR DESCRIPTION
This PR adds missing -latest suffix for 2.2.0 RC1 docker upstream tag. 
We missed adding this suffix when we cut RC1 for 2.2.0 release, which was causing docker builds to fail with image tag not found error. This change will resolve the failing docker builds.