### PR TITLE
[MMA-16967]- install ca certs in prometheus/AM images post upgrade to of base image to ubi9

### DIFF
--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -76,6 +76,7 @@ ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 LABEL io.confluent.docker.git.repo="confluentinc/control-center-images"
 
+RUN microdnf install -y ca-certificates && microdnf clean all
 
 RUN mkdir -p /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager && \
     mkdir -p /etc/confluent-control-center

--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -43,6 +43,7 @@ gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && microdnf install -y confluent-${COMPONENT}-${C3_VERSION} \
+    && microdnf install -y ca-certificates \
     && echo "===> Cleaning up ..."  \
     && microdnf clean all \
     && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
@@ -76,8 +77,6 @@ ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 LABEL io.confluent.docker.git.repo="confluentinc/control-center-images"
 
-RUN microdnf install -y ca-certificates && microdnf clean all
-
 RUN mkdir -p /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager && \
     mkdir -p /etc/confluent-control-center
 
@@ -87,6 +86,9 @@ COPY --from=builder /etc/confluent-control-center/ /etc/confluent-control-center
 COPY --from=builder /usr/bin/alertmanager-start /usr/bin/alertmanager-start
 COPY --from=builder /usr/bin/alertmanager-stop /usr/bin/alertmanager-stop
 COPY --from=builder /licenses /licenses
+COPY --from=builder /etc/pki/ca-trust /etc/pki/ca-trust
+COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+
 EXPOSE 9093
 
 RUN chmod +x /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/alertmanager-${ARCH#.}

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -44,7 +44,7 @@ gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && microdnf install -y confluent-${COMPONENT}-${C3_VERSION} \
-    && RUN microdnf install -y ca-certificates \
+    && microdnf install -y ca-certificates \
     && echo "===> Cleaning up ..."  \
     && microdnf clean all \
     && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -77,6 +77,8 @@ ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 LABEL io.confluent.docker.git.repo="confluentinc/control-center-images"
 
+RUN microdnf install -y ca-certificates && microdnf clean all
+
 RUN mkdir -p /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus && \
     mkdir -p /etc/confluent-control-center
 

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -44,6 +44,7 @@ gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && microdnf install -y confluent-${COMPONENT}-${C3_VERSION} \
+    && RUN microdnf install -y ca-certificates \
     && echo "===> Cleaning up ..."  \
     && microdnf clean all \
     && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
@@ -77,8 +78,6 @@ ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 LABEL io.confluent.docker.git.repo="confluentinc/control-center-images"
 
-RUN microdnf install -y ca-certificates && microdnf clean all
-
 RUN mkdir -p /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus && \
     mkdir -p /etc/confluent-control-center
 
@@ -88,7 +87,8 @@ COPY --from=builder /etc/confluent-control-center/ /etc/confluent-control-center
 COPY --from=builder /usr/bin/prometheus-start /usr/bin/prometheus-start
 COPY --from=builder /usr/bin/prometheus-stop /usr/bin/prometheus-stop
 COPY --from=builder /licenses /licenses
-
+COPY --from=builder /etc/pki/ca-trust /etc/pki/ca-trust
+COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 
 EXPOSE 9090
 


### PR DESCRIPTION
## Issue
ca certs are missing in prometheus and alertmanager after updating base image to ubi9

## Impact
notification of slack/pagerduty/webhook were no longer working which use a webhook url to notify, giving cert error.

## Fix
With ubi9 ca-certs were removed, we need to separately install. This has been done now.

## Testing
Deployed the new image with the fix and tested E2E notification
<img width="529" alt="image" src="https://github.com/user-attachments/assets/00955b05-7f32-41e6-baf3-fcda53f88a05" />
