### PR TITLE
MMA-16911 | remove duplicate jars in usr/share/java

### DIFF
--- a/control-center/Dockerfile.ubi9
+++ b/control-center/Dockerfile.ubi9
@@ -58,6 +58,8 @@ gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && microdnf install -y confluent-${COMPONENT}-${C3_VERSION} \
+    && echo "===> Deduping jars present in /usr/share/java ..." \
+    && package_dedupe /usr/share/java \
     && echo "===> Cleaning up ..."  \
     && microdnf clean all \
     && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \


### PR DESCRIPTION
To test dedupe of jars within java will reduce the jars included with acl and control-center