### PR TITLE
MMA-18752: Migrate Docker images from ubi9-minimal to ubi9-micro base

### DIFF
--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -13,48 +13,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG UBI_MINIMAL_VERSION
+ARG UBI9_VERSION
 ARG UBI_MICRO_VERSION
 
-FROM registry.access.redhat.com/ubi9-minimal:${UBI_MINIMAL_VERSION} as builder
-
-ARG PROJECT_VERSION
-ARG ARTIFACT_ID
-ARG GIT_COMMIT
-
-ENV COMPONENT=control-center-next-gen
-ENV OLD_COMPONENT_NAME=control-center
-ENV CONTROL_CENTER_DATA_DIR=/var/lib/confluent-${COMPONENT}
-ENV CONTROL_CENTER_CONFIG_DIR=/etc/confluent-${OLD_COMPONENT_NAME}
+# Stage 1: Install packages to /microdir using full ubi9 with dnf
+FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} AS builder
 
 ARG C3_VERSION
 ARG CONFLUENT_PACKAGES_REPO
-ARG CONFLUENT_PLATFORM_LABEL
 
-USER root
-
-RUN echo "===> Installing ${COMPONENT}..." \
-    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
+RUN rpm --import "${CONFLUENT_PACKAGES_REPO}/archive.key" \
     && printf "[Confluent] \n\
 name=Confluent repository \n\
 baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && microdnf install -y confluent-${COMPONENT}-${C3_VERSION} \
-    && microdnf install -y ca-certificates \
-    && echo "===> Creating appuser..." \
-    && useradd --no-log-init --create-home --shell /bin/bash appuser \
-    && echo "===> Cleaning up ..."  \
-    && microdnf clean all \
-    && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
-    && echo "===> Setting up ${COMPONENT} dirs" \
-    && mkdir -p "${CONTROL_CENTER_DATA_DIR}" \
-    && chown appuser:root -R "${CONTROL_CENTER_DATA_DIR}" \
-    && chown appuser:root -R "${CONTROL_CENTER_CONFIG_DIR}" \
-    && chmod -R ug+w "${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"
+    && mkdir -p /microdir
 
-FROM registry.access.redhat.com/ubi9/ubi-micro:${UBI_MICRO_VERSION}
+RUN echo "===> Installing control-center-next-gen..." \
+    && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs \
+       "confluent-control-center-next-gen-${C3_VERSION}" \
+       ca-certificates \
+    && echo "===> Cleaning up ..." \
+    && dnf --installroot=/microdir clean all \
+    && rm -rf /microdir/var/cache/* /microdir/var/log/dnf* /microdir/var/log/yum.* /microdir/tmp/* \
+    && rm /etc/yum.repos.d/confluent.repo \
+    && rm -rf /microdir/dev/* /microdir/proc/* /microdir/sys/*
+
+
+# Stage 2: Final image using ubi9-micro
+FROM registry.access.redhat.com/ubi9-micro:${UBI_MICRO_VERSION}
+
 WORKDIR /app
 USER root
 
@@ -62,8 +52,7 @@ ARG ARCH
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 ARG GIT_COMMIT
-
-# Update package list and install essential packages
+ARG BUILD_NUMBER=-1
 
 LABEL maintainer="partner-support@confluent.io"
 LABEL vendor="Confluent"
@@ -74,20 +63,18 @@ LABEL summary="Alertmanager is an alerting system that integrates with Prometheu
 LABEL description="Alertmanager is an alerting system that integrates with Prometheus, used as backend for Next Gen C3"
 LABEL io.confluent.docker=true
 LABEL io.confluent.docker.git.id=$GIT_COMMIT
-ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 LABEL io.confluent.docker.git.repo="confluentinc/control-center-images"
 
 RUN mkdir -p /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager && \
     mkdir -p /etc/confluent-control-center
 
-# Use the cleaned ARCH variable in subsequent commands
-COPY --from=builder /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/ /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/
-COPY --from=builder /etc/confluent-control-center/ /etc/confluent-control-center/
-COPY --from=builder /usr/bin/alertmanager-start /usr/bin/alertmanager-start
-COPY --from=builder /usr/bin/alertmanager-stop /usr/bin/alertmanager-stop
-COPY --from=builder /etc/pki/ca-trust /etc/pki/ca-trust
-COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+COPY --from=builder /microdir/usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/ /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/
+COPY --from=builder /microdir/etc/confluent-control-center/ /etc/confluent-control-center/
+COPY --from=builder /microdir/usr/bin/alertmanager-start /usr/bin/alertmanager-start
+COPY --from=builder /microdir/usr/bin/alertmanager-stop /usr/bin/alertmanager-stop
+COPY --from=builder /microdir/etc/pki/ca-trust /etc/pki/ca-trust
+COPY --from=builder /microdir/etc/ssl/certs /etc/ssl/certs
 
 EXPOSE 9093
 
@@ -97,11 +84,9 @@ COPY license.txt /licenses/
 RUN chmod +x /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/alertmanager-${ARCH#.}
 WORKDIR /usr/bin
 
-
 RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
     mkdir -p /home/appuser && \
     chown 1000:1000 /home/appuser
-
 
 ## Creating the default log directory and data directory utilized by the script to ensure that Alertmanager
 ## can write data during its execution.
@@ -111,9 +96,8 @@ RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
 RUN mkdir -p /var/lib/confluent/control-center/alertmanager/ && \
     mkdir -p /var/log/confluent/control-center && \
     chown -R 1000:1000 /etc/confluent-control-center /var/lib/confluent/control-center/alertmanager/ /var/log/confluent/control-center
+
 USER appuser
 
-VOLUME     [ "/var/lib/confluent/control-center/prometheus/data" ]
+VOLUME [ "/var/lib/confluent/control-center/prometheus/data" ]
 ENTRYPOINT [ "alertmanager-start" ]
-
-

--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -99,5 +99,5 @@ RUN mkdir -p /var/lib/confluent/control-center/alertmanager/ && \
 
 USER appuser
 
-VOLUME [ "/var/lib/confluent/control-center/prometheus/data" ]
+VOLUME [ "/var/lib/confluent/control-center/alertmanager/" ]
 ENTRYPOINT [ "alertmanager-start" ]

--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -19,7 +19,7 @@ ARG APP_GID=1000
 ARG UBI9_VERSION
 ARG UBI_MICRO_VERSION
 
-FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} as builder
+FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} AS builder
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
@@ -37,14 +37,14 @@ ARG CONFLUENT_PLATFORM_LABEL
 USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
-    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
+    && rpm --import "${CONFLUENT_PACKAGES_REPO}/archive.key" \
     && printf "[Confluent] \n\
 name=Confluent repository \n\
 baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && dnf install -y --installroot=/microdir --releasever=9 confluent-${COMPONENT}-${C3_VERSION} ca-certificates \
+    && dnf install -y --installroot=/microdir --releasever=9 "confluent-${COMPONENT}-${C3_VERSION}" ca-certificates \
     && echo "===> Creating appuser..." \
     && useradd --no-log-init --create-home --shell /bin/bash appuser \
     && echo "===> Cleaning up ..."  \
@@ -108,7 +108,7 @@ WORKDIR /usr/bin
 RUN echo "appuser:x:${APP_UID}:${APP_GID}::/home/appuser:/bin/sh" >> /etc/passwd && \
     echo "appuser:x:${APP_GID}:" >> /etc/group && \
     mkdir -p /home/appuser && \
-    chown ${APP_UID}:${APP_GID} /home/appuser
+    chown "${APP_UID}:${APP_GID}" /home/appuser
 
 
 ## Creating the default log directory and data directory utilized by the script to ensure that Alertmanager
@@ -118,7 +118,7 @@ RUN echo "appuser:x:${APP_UID}:${APP_GID}::/home/appuser:/bin/sh" >> /etc/passwd
 ## Security Practice: Adheres to the principle of least privilege.
 RUN mkdir -p /var/lib/confluent/control-center/alertmanager/ && \
     mkdir -p /var/log/confluent/control-center && \
-    chown -R ${APP_UID}:${APP_GID} /etc/confluent-control-center /var/lib/confluent/control-center/alertmanager/ /var/log/confluent/control-center
+    chown -R "${APP_UID}:${APP_GID}" /etc/confluent-control-center /var/lib/confluent/control-center/alertmanager/ /var/log/confluent/control-center
 USER ${APP_UID}
 
 VOLUME     [ "/var/lib/confluent/control-center/alertmanager" ]

--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -13,38 +13,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG UBI9_VERSION
+ARG UBI_MINIMAL_VERSION
 ARG UBI_MICRO_VERSION
 
-# Stage 1: Install packages to /microdir using full ubi9 with dnf
-FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} AS builder
+FROM registry.access.redhat.com/ubi9-minimal:${UBI_MINIMAL_VERSION} as builder
+
+ARG PROJECT_VERSION
+ARG ARTIFACT_ID
+ARG GIT_COMMIT
+
+ENV COMPONENT=control-center-next-gen
+ENV OLD_COMPONENT_NAME=control-center
+ENV CONTROL_CENTER_DATA_DIR=/var/lib/confluent-${COMPONENT}
+ENV CONTROL_CENTER_CONFIG_DIR=/etc/confluent-${OLD_COMPONENT_NAME}
 
 ARG C3_VERSION
 ARG CONFLUENT_PACKAGES_REPO
+ARG CONFLUENT_PLATFORM_LABEL
 
-RUN rpm --import "${CONFLUENT_PACKAGES_REPO}/archive.key" \
+USER root
+
+RUN echo "===> Installing ${COMPONENT}..." \
+    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
     && printf "[Confluent] \n\
 name=Confluent repository \n\
 baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && mkdir -p /microdir
+    && microdnf install -y confluent-${COMPONENT}-${C3_VERSION} \
+    && microdnf install -y ca-certificates \
+    && echo "===> Creating appuser..." \
+    && useradd --no-log-init --create-home --shell /bin/bash appuser \
+    && echo "===> Cleaning up ..."  \
+    && microdnf clean all \
+    && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
+    && echo "===> Setting up ${COMPONENT} dirs" \
+    && mkdir -p "${CONTROL_CENTER_DATA_DIR}" \
+    && chown appuser:root -R "${CONTROL_CENTER_DATA_DIR}" \
+    && chown appuser:root -R "${CONTROL_CENTER_CONFIG_DIR}" \
+    && chmod -R ug+w "${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"
 
-RUN echo "===> Installing control-center-next-gen..." \
-    && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs \
-       "confluent-control-center-next-gen-${C3_VERSION}" \
-       ca-certificates \
-    && echo "===> Cleaning up ..." \
-    && dnf --installroot=/microdir clean all \
-    && rm -rf /microdir/var/cache/* /microdir/var/log/dnf* /microdir/var/log/yum.* /microdir/tmp/* \
-    && rm /etc/yum.repos.d/confluent.repo \
-    && rm -rf /microdir/dev/* /microdir/proc/* /microdir/sys/*
-
-
-# Stage 2: Final image using ubi9-micro
-FROM registry.access.redhat.com/ubi9-micro:${UBI_MICRO_VERSION}
-
+FROM registry.access.redhat.com/ubi9/ubi-micro:${UBI_MICRO_VERSION}
 WORKDIR /app
 USER root
 
@@ -52,7 +62,8 @@ ARG ARCH
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 ARG GIT_COMMIT
-ARG BUILD_NUMBER=-1
+
+# Update package list and install essential packages
 
 LABEL maintainer="partner-support@confluent.io"
 LABEL vendor="Confluent"
@@ -63,18 +74,20 @@ LABEL summary="Alertmanager is an alerting system that integrates with Prometheu
 LABEL description="Alertmanager is an alerting system that integrates with Prometheus, used as backend for Next Gen C3"
 LABEL io.confluent.docker=true
 LABEL io.confluent.docker.git.id=$GIT_COMMIT
+ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 LABEL io.confluent.docker.git.repo="confluentinc/control-center-images"
 
 RUN mkdir -p /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager && \
     mkdir -p /etc/confluent-control-center
 
-COPY --from=builder /microdir/usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/ /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/
-COPY --from=builder /microdir/etc/confluent-control-center/ /etc/confluent-control-center/
-COPY --from=builder /microdir/usr/bin/alertmanager-start /usr/bin/alertmanager-start
-COPY --from=builder /microdir/usr/bin/alertmanager-stop /usr/bin/alertmanager-stop
-COPY --from=builder /microdir/etc/pki/ca-trust /etc/pki/ca-trust
-COPY --from=builder /microdir/etc/ssl/certs /etc/ssl/certs
+# Use the cleaned ARCH variable in subsequent commands
+COPY --from=builder /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/ /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/
+COPY --from=builder /etc/confluent-control-center/ /etc/confluent-control-center/
+COPY --from=builder /usr/bin/alertmanager-start /usr/bin/alertmanager-start
+COPY --from=builder /usr/bin/alertmanager-stop /usr/bin/alertmanager-stop
+COPY --from=builder /etc/pki/ca-trust /etc/pki/ca-trust
+COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 
 EXPOSE 9093
 
@@ -84,9 +97,11 @@ COPY license.txt /licenses/
 RUN chmod +x /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/alertmanager-${ARCH#.}
 WORKDIR /usr/bin
 
+
 RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
     mkdir -p /home/appuser && \
     chown 1000:1000 /home/appuser
+
 
 ## Creating the default log directory and data directory utilized by the script to ensure that Alertmanager
 ## can write data during its execution.
@@ -96,7 +111,6 @@ RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
 RUN mkdir -p /var/lib/confluent/control-center/alertmanager/ && \
     mkdir -p /var/log/confluent/control-center && \
     chown -R 1000:1000 /etc/confluent-control-center /var/lib/confluent/control-center/alertmanager/ /var/log/confluent/control-center
-
 USER appuser
 
 VOLUME     [ "/var/lib/confluent/control-center/prometheus/data" ]

--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ARG APP_UID=1000
+ARG APP_GID=1000
+
 ARG UBI_MINIMAL_VERSION
 ARG UBI_MICRO_VERSION
 
@@ -58,10 +61,15 @@ FROM registry.access.redhat.com/ubi9/ubi-micro:${UBI_MICRO_VERSION}
 WORKDIR /app
 USER root
 
+ARG APP_UID
+ARG APP_GID
 ARG ARCH
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 ARG GIT_COMMIT
+
+ENV APP_UID=${APP_UID}
+ENV APP_GID=${APP_GID}
 
 # Update package list and install essential packages
 
@@ -98,9 +106,10 @@ RUN chmod +x /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/
 WORKDIR /usr/bin
 
 
-RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
+RUN echo "appuser:x:${APP_UID}:${APP_GID}::/home/appuser:/bin/sh" >> /etc/passwd && \
+    echo "appuser:x:${APP_GID}:" >> /etc/group && \
     mkdir -p /home/appuser && \
-    chown 1000:1000 /home/appuser
+    chown ${APP_UID}:${APP_GID} /home/appuser
 
 
 ## Creating the default log directory and data directory utilized by the script to ensure that Alertmanager
@@ -110,8 +119,8 @@ RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
 ## Security Practice: Adheres to the principle of least privilege.
 RUN mkdir -p /var/lib/confluent/control-center/alertmanager/ && \
     mkdir -p /var/log/confluent/control-center && \
-    chown -R 1000:1000 /etc/confluent-control-center /var/lib/confluent/control-center/alertmanager/ /var/log/confluent/control-center
-USER appuser
+    chown -R ${APP_UID}:${APP_GID} /etc/confluent-control-center /var/lib/confluent/control-center/alertmanager/ /var/log/confluent/control-center
+USER ${APP_UID}
 
 VOLUME     [ "/var/lib/confluent/control-center/prometheus/data" ]
 ENTRYPOINT [ "alertmanager-start" ]

--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -99,5 +99,7 @@ RUN mkdir -p /var/lib/confluent/control-center/alertmanager/ && \
 
 USER appuser
 
-VOLUME [ "/var/lib/confluent/control-center/alertmanager/" ]
+VOLUME     [ "/var/lib/confluent/control-center/prometheus/data" ]
 ENTRYPOINT [ "alertmanager-start" ]
+
+

--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -16,10 +16,10 @@
 ARG APP_UID=1000
 ARG APP_GID=1000
 
-ARG UBI_MINIMAL_VERSION
+ARG UBI9_VERSION
 ARG UBI_MICRO_VERSION
 
-FROM registry.access.redhat.com/ubi9-minimal:${UBI_MINIMAL_VERSION} as builder
+FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} as builder
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
@@ -44,18 +44,18 @@ baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && microdnf install -y confluent-${COMPONENT}-${C3_VERSION} \
-    && microdnf install -y ca-certificates \
+    && dnf install -y --installroot=/microdir --releasever=9 confluent-${COMPONENT}-${C3_VERSION} \
+    && dnf install -y --installroot=/microdir --releasever=9 ca-certificates \
     && echo "===> Creating appuser..." \
     && useradd --no-log-init --create-home --shell /bin/bash appuser \
     && echo "===> Cleaning up ..."  \
-    && microdnf clean all \
+    && dnf --installroot=/microdir clean all \
     && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
     && echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p "${CONTROL_CENTER_DATA_DIR}" \
     && chown appuser:root -R "${CONTROL_CENTER_DATA_DIR}" \
-    && chown appuser:root -R "${CONTROL_CENTER_CONFIG_DIR}" \
-    && chmod -R ug+w "${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"
+    && chown appuser:root -R "/microdir${CONTROL_CENTER_CONFIG_DIR}" \
+    && chmod -R ug+w "/microdir${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"
 
 FROM registry.access.redhat.com/ubi9/ubi-micro:${UBI_MICRO_VERSION}
 WORKDIR /app
@@ -90,12 +90,12 @@ RUN mkdir -p /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager 
     mkdir -p /etc/confluent-control-center
 
 # Use the cleaned ARCH variable in subsequent commands
-COPY --from=builder /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/ /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/
-COPY --from=builder /etc/confluent-control-center/ /etc/confluent-control-center/
-COPY --from=builder /usr/bin/alertmanager-start /usr/bin/alertmanager-start
-COPY --from=builder /usr/bin/alertmanager-stop /usr/bin/alertmanager-stop
-COPY --from=builder /etc/pki/ca-trust /etc/pki/ca-trust
-COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+COPY --from=builder /microdir/usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/ /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/
+COPY --from=builder /microdir/etc/confluent-control-center/ /etc/confluent-control-center/
+COPY --from=builder /microdir/usr/bin/alertmanager-start /usr/bin/alertmanager-start
+COPY --from=builder /microdir/usr/bin/alertmanager-stop /usr/bin/alertmanager-stop
+COPY --from=builder /microdir/etc/pki/ca-trust /etc/pki/ca-trust
+COPY --from=builder /microdir/etc/ssl/certs /etc/ssl/certs
 
 EXPOSE 9093
 

--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ARG APP_UID=1000
+ARG APP_GID=1000
+
 ARG UBI_MINIMAL_VERSION
 ARG UBI_MICRO_VERSION
 
@@ -58,10 +61,15 @@ FROM registry.access.redhat.com/ubi9/ubi-micro:${UBI_MICRO_VERSION}
 WORKDIR /app
 USER root
 
+ARG APP_UID
+ARG APP_GID
 ARG ARCH
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 ARG GIT_COMMIT
+
+ENV APP_UID=${APP_UID}
+ENV APP_GID=${APP_GID}
 
 # Update package list and install essential packages
 
@@ -98,9 +106,10 @@ RUN chmod +x /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/
 WORKDIR /usr/bin
 
 
-RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
+RUN echo "appuser:x:${APP_UID}:${APP_GID}::/home/appuser:/bin/sh" >> /etc/passwd && \
+    echo "appuser:x:${APP_GID}:" >> /etc/group && \
     mkdir -p /home/appuser && \
-    chown 1000:1000 /home/appuser
+    chown ${APP_UID}:${APP_GID} /home/appuser
 
 
 ## Creating the default log directory and data directory utilized by the script to ensure that Alertmanager
@@ -110,10 +119,10 @@ RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
 ## Security Practice: Adheres to the principle of least privilege.
 RUN mkdir -p /var/lib/confluent/control-center/alertmanager/ && \
     mkdir -p /var/log/confluent/control-center && \
-    chown -R 1000:1000 /etc/confluent-control-center /var/lib/confluent/control-center/alertmanager/ /var/log/confluent/control-center
-USER appuser
+    chown -R ${APP_UID}:${APP_GID} /etc/confluent-control-center /var/lib/confluent/control-center/alertmanager/ /var/log/confluent/control-center
+USER ${APP_UID}
 
-VOLUME     [ "/var/lib/confluent/control-center/prometheus/data" ]
+VOLUME     [ "/var/lib/confluent/control-center/alertmanager/" ]
 ENTRYPOINT [ "alertmanager-start" ]
 
 

--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -44,8 +44,7 @@ baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && dnf install -y --installroot=/microdir --releasever=9 confluent-${COMPONENT}-${C3_VERSION} \
-    && dnf install -y --installroot=/microdir --releasever=9 ca-certificates \
+    && dnf install -y --installroot=/microdir --releasever=9 confluent-${COMPONENT}-${C3_VERSION} ca-certificates \
     && echo "===> Creating appuser..." \
     && useradd --no-log-init --create-home --shell /bin/bash appuser \
     && echo "===> Cleaning up ..."  \

--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG APP_UID=1000
-ARG APP_GID=1000
-
 ARG UBI_MINIMAL_VERSION
 ARG UBI_MICRO_VERSION
 
@@ -61,15 +58,10 @@ FROM registry.access.redhat.com/ubi9/ubi-micro:${UBI_MICRO_VERSION}
 WORKDIR /app
 USER root
 
-ARG APP_UID
-ARG APP_GID
 ARG ARCH
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 ARG GIT_COMMIT
-
-ENV APP_UID=${APP_UID}
-ENV APP_GID=${APP_GID}
 
 # Update package list and install essential packages
 
@@ -106,10 +98,9 @@ RUN chmod +x /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/
 WORKDIR /usr/bin
 
 
-RUN echo "appuser:x:${APP_UID}:${APP_GID}::/home/appuser:/bin/sh" >> /etc/passwd && \
-    echo "appuser:x:${APP_GID}:" >> /etc/group && \
+RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
     mkdir -p /home/appuser && \
-    chown ${APP_UID}:${APP_GID} /home/appuser
+    chown 1000:1000 /home/appuser
 
 
 ## Creating the default log directory and data directory utilized by the script to ensure that Alertmanager
@@ -119,10 +110,10 @@ RUN echo "appuser:x:${APP_UID}:${APP_GID}::/home/appuser:/bin/sh" >> /etc/passwd
 ## Security Practice: Adheres to the principle of least privilege.
 RUN mkdir -p /var/lib/confluent/control-center/alertmanager/ && \
     mkdir -p /var/log/confluent/control-center && \
-    chown -R ${APP_UID}:${APP_GID} /etc/confluent-control-center /var/lib/confluent/control-center/alertmanager/ /var/log/confluent/control-center
-USER ${APP_UID}
+    chown -R 1000:1000 /etc/confluent-control-center /var/lib/confluent/control-center/alertmanager/ /var/log/confluent/control-center
+USER appuser
 
-VOLUME     [ "/var/lib/confluent/control-center/alertmanager/" ]
+VOLUME     [ "/var/lib/confluent/control-center/prometheus/data" ]
 ENTRYPOINT [ "alertmanager-start" ]
 
 

--- a/control-center/Dockerfile.ubi9
+++ b/control-center/Dockerfile.ubi9
@@ -67,9 +67,9 @@ RUN echo "===> Installing Temurin JRE..." \
     && echo "===> Deduping jars in /microdir ..." \
     && package_dedupe /microdir/usr/share/java \
     && echo "===> Removing unused services (Prometheus, Alertmanager)..." \
-    && rm -f /microdir/usr/lib/systemd/system/prometheus.service \
+    && rm -f /microdir/lib/systemd/system/prometheus.service \
     && rm -rf /microdir/usr/libexec/confluent-control-center/linux_*/prometheus \
-    && rm -f /microdir/usr/lib/systemd/system/alertmanager.service \
+    && rm -f /microdir/lib/systemd/system/alertmanager.service \
     && rm -rf /microdir/usr/libexec/confluent-control-center/linux_*/alertmanager \
     && echo "===> Cleaning up ..." \
     && dnf --installroot=/microdir clean all \

--- a/control-center/Dockerfile.ubi9
+++ b/control-center/Dockerfile.ubi9
@@ -57,11 +57,9 @@ gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && mkdir -p /microdir
 
-RUN echo "===> Installing Temurin JRE..." \
+RUN echo "===> Installing Temurin JRE and Control Center Next Gen..." \
     && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs \
        "temurin-21-jre${TEMURIN_JDK_VERSION}" \
-    && echo "===> Installing Control Center Next Gen..." \
-    && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs \
        "confluent-control-center-next-gen-${C3_VERSION}" \
        shadow-utils \
     && echo "===> Deduping jars in /microdir ..." \

--- a/control-center/Dockerfile.ubi9
+++ b/control-center/Dockerfile.ubi9
@@ -66,9 +66,9 @@ RUN echo "===> Installing Temurin JRE..." \
     && echo "===> Deduping jars in /microdir ..." \
     && package_dedupe /microdir/usr/share/java \
     && echo "===> Removing unused services (Prometheus, Alertmanager)..." \
-    && rm /microdir/usr/lib/systemd/system/prometheus.service \
+    && rm -f /microdir/usr/lib/systemd/system/prometheus.service \
     && rm -rf /microdir/usr/libexec/confluent-control-center/linux_*/prometheus \
-    && rm /microdir/usr/lib/systemd/system/alertmanager.service \
+    && rm -f /microdir/usr/lib/systemd/system/alertmanager.service \
     && rm -rf /microdir/usr/libexec/confluent-control-center/linux_*/alertmanager \
     && echo "===> Cleaning up ..." \
     && dnf --installroot=/microdir clean all \

--- a/control-center/Dockerfile.ubi9
+++ b/control-center/Dockerfile.ubi9
@@ -63,6 +63,7 @@ RUN echo "===> Installing Temurin JRE..." \
     && echo "===> Installing Control Center Next Gen..." \
     && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs \
        "confluent-control-center-next-gen-${C3_VERSION}" \
+       shadow-utils \
     && echo "===> Deduping jars in /microdir ..." \
     && package_dedupe /microdir/usr/share/java \
     && echo "===> Removing unused services (Prometheus, Alertmanager)..." \

--- a/control-center/Dockerfile.ubi9
+++ b/control-center/Dockerfile.ubi9
@@ -13,8 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ARG APP_UID=1000
+ARG APP_GID=1000
+
 ARG GOLANG_VERSION
-ARG UBI_MINIMAL_VERSION
+ARG UBI9_VERSION
+ARG UBI_MICRO_VERSION
+
+# Stage 1: Build ub and package_dedupe utility binaries
 FROM docker.io/golang:${GOLANG_VERSION} AS build-utilities
 
 ARG CP_DOCKER_UTILS_VERSION
@@ -24,16 +30,72 @@ RUN CGO_ENABLED=0 go install -ldflags="-w -s" github.com/confluentinc/cp-docker-
 RUN CGO_ENABLED=0 go install -ldflags="-w -s" github.com/confluentinc/cp-docker-utils/cmd/package_dedupe@${CP_DOCKER_UTILS_VERSION}
 
 
-FROM registry.access.redhat.com/ubi9-minimal:${UBI_MINIMAL_VERSION}
+# Stage 2: Install packages to /microdir using full ubi9 with dnf
+FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} AS builder
 
+ARG APP_UID
+ARG APP_GID
+ARG TEMURIN_JDK_VERSION
+ARG C3_VERSION
+ARG CONFLUENT_PACKAGES_REPO
+
+COPY --from=build-utilities /go/bin/package_dedupe /usr/local/bin/package_dedupe
+
+RUN printf "[temurin-jre] \n\
+name=temurin-jre \n\
+baseurl=https://adoptium.jfrog.io/artifactory/rpm/rhel/\$releasever/\$basearch \n\
+enabled=1 \n\
+gpgcheck=1 \n\
+gpgkey=https://adoptium.jfrog.io/artifactory/api/gpg/key/public \n\
+" > /etc/yum.repos.d/adoptium.repo \
+    && rpm --import "${CONFLUENT_PACKAGES_REPO}/archive.key" \
+    && printf "[Confluent] \n\
+name=Confluent repository \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 " > /etc/yum.repos.d/confluent.repo \
+    && mkdir -p /microdir
+
+RUN echo "===> Installing Temurin JRE..." \
+    && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs \
+       "temurin-21-jre${TEMURIN_JDK_VERSION}" \
+    && echo "===> Installing Control Center Next Gen..." \
+    && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs \
+       "confluent-control-center-next-gen-${C3_VERSION}" \
+    && echo "===> Deduping jars in /microdir ..." \
+    && package_dedupe /microdir/usr/share/java \
+    && echo "===> Removing unused services (Prometheus, Alertmanager)..." \
+    && rm /microdir/usr/lib/systemd/system/prometheus.service \
+    && rm -rf /microdir/usr/libexec/confluent-control-center/linux_*/prometheus \
+    && rm /microdir/usr/lib/systemd/system/alertmanager.service \
+    && rm -rf /microdir/usr/libexec/confluent-control-center/linux_*/alertmanager \
+    && echo "===> Cleaning up ..." \
+    && dnf --installroot=/microdir clean all \
+    && rm -rf /microdir/var/cache/* /microdir/var/log/dnf* /microdir/var/log/yum.* /microdir/tmp/* \
+    && rm /etc/yum.repos.d/adoptium.repo /etc/yum.repos.d/confluent.repo \
+    && rm -rf /microdir/lib/systemd \
+    && rm -rf /microdir/dev/* /microdir/proc/* /microdir/sys/*
+
+RUN echo "===> Creating appuser..." \
+    && chroot /microdir groupadd -g "${APP_GID}" appuser \
+    && chroot /microdir useradd -u "${APP_UID}" -g "${APP_GID}" --no-log-init --create-home --shell /bin/bash appuser
+
+
+# Stage 3: Final image using ubi9-micro
+FROM registry.access.redhat.com/ubi9-micro:${UBI_MICRO_VERSION}
+
+ARG APP_UID
+ARG APP_GID
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 ARG GIT_COMMIT
 ARG BUILD_NUMBER=-1
-ARG TEMURIN_JDK_VERSION
 ARG C3_VERSION
-ARG CONFLUENT_PACKAGES_REPO
 ARG CONFLUENT_PLATFORM_LABEL
+
+ENV APP_UID=${APP_UID}
+ENV APP_GID=${APP_GID}
 
 LABEL maintainer="partner-support@confluent.io"
 LABEL vendor="Confluent"
@@ -57,66 +119,30 @@ EXPOSE 9021
 
 USER root
 
-# Install cp-base-java dependencies (Temurin JRE)
-RUN printf "[temurin-jre] \n\
-name=temurin-jre \n\
-baseurl=https://adoptium.jfrog.io/artifactory/rpm/rhel/\$releasever/\$basearch \n\
-enabled=1 \n\
-gpgcheck=1 \n\
-gpgkey=https://adoptium.jfrog.io/artifactory/api/gpg/key/public \n\
-" > /etc/yum.repos.d/adoptium.repo \
-    && echo "===> Installing Temurin JRE..." \
-    && microdnf install -y temurin-21-jre${TEMURIN_JDK_VERSION} \
-    && microdnf clean all \
-    && echo "===> Creating appuser and directories..." \
-    && useradd --no-log-init --create-home --shell /bin/bash appuser \
-    && mkdir -p /etc/confluent/docker /usr/logs \
-    && chown appuser:appuser -R /etc/confluent/ /usr/logs \
-    && mkdir /licenses \
-    && rm /etc/yum.repos.d/adoptium.repo
-
 COPY --from=build-utilities /go/bin/ub /usr/bin/ub
 COPY --from=build-utilities /go/bin/package_dedupe /usr/bin/package_dedupe
+COPY --from=builder /microdir/ /
 
-RUN echo "===> Installing ${COMPONENT}..." \
-    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
-    && printf "[Confluent] \n\
-name=Confluent repository \n\
-baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
-gpgcheck=1 \n\
-gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
-enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && microdnf install -y confluent-${COMPONENT}-${C3_VERSION} \
-    && echo "===> Deduping jars present in /usr/share/java ..." \
-    && package_dedupe /usr/share/java \
-    && echo "===> Cleaning up ..." \
-    && microdnf clean all \
-    && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
-    && echo "===> Setting up ${COMPONENT} dirs" \
+RUN mkdir -p /etc/confluent/docker /usr/logs /licenses \
+    && chown "${APP_UID}:${APP_GID}" -R /etc/confluent/ /usr/logs
+
+RUN echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p "${CONTROL_CENTER_DATA_DIR}" \
-    && chown appuser:root -R "${CONTROL_CENTER_DATA_DIR}" \
-    && chown appuser:root -R "${CONTROL_CENTER_CONFIG_DIR}" \
-    && chmod -R ug+w "${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"\
-    && echo "===> Removing unused services (Prometheus, Alertmanager)..." \
-    && rm /usr/lib/systemd/system/prometheus.service && \
-    rm -r /usr/libexec/confluent-control-center/linux_*/prometheus && \
-    rm /usr/lib/systemd/system/alertmanager.service && \
-    rm -r /usr/libexec/confluent-control-center/linux_*/alertmanager
+    && chown "${APP_UID}":root -R "${CONTROL_CENTER_DATA_DIR}" "${CONTROL_CENTER_CONFIG_DIR}" \
+    && chmod -R ug+w "${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"
 
-
-# Copy files from target package to cp-base-new directory for backward compatibility (some paths are hardcoded in CFK startups scripts)
-COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/cp-base-new/
-COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/cp-base-new/
+# Copy files from target package to cp-base-new directory for backward compatibility (some paths are hardcoded in CFK startup scripts)
+COPY --chown=${APP_UID}:${APP_GID} target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/cp-base-new/
+COPY --chown=${APP_UID}:${APP_GID} target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/cp-base-new/
 
 # /usr/share/java/cp-base-java is the default java classpath for ub
 # jars in cp-base-new and cp-base-java are identical, so create a symlink to avoid duplicating files
 RUN ln -s /usr/share/java/cp-base-new /usr/share/java/cp-base-java
 
-
-COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
+COPY --chown=${APP_UID}:${APP_GID} include/etc/confluent/docker /etc/confluent/docker
 COPY license.txt /licenses/
 
-USER appuser
+USER ${APP_UID}
 WORKDIR /home/appuser
 
 CMD ["/etc/confluent/docker/run"]

--- a/control-center/Dockerfile.ubi9
+++ b/control-center/Dockerfile.ubi9
@@ -20,14 +20,13 @@ ARG GOLANG_VERSION
 ARG UBI9_VERSION
 ARG UBI_MICRO_VERSION
 
-# Stage 1: Build ub and package_dedupe utility binaries
+# Stage 1: Build ub utility binary
 FROM docker.io/golang:${GOLANG_VERSION} AS build-utilities
 
 ARG CP_DOCKER_UTILS_VERSION
 
 ENV GO_BIN="/go/bin"
 RUN CGO_ENABLED=0 go install -ldflags="-w -s" github.com/confluentinc/cp-docker-utils/cmd/ub@${CP_DOCKER_UTILS_VERSION}
-RUN CGO_ENABLED=0 go install -ldflags="-w -s" github.com/confluentinc/cp-docker-utils/cmd/package_dedupe@${CP_DOCKER_UTILS_VERSION}
 
 
 # Stage 2: Install packages to /microdir using full ubi9 with dnf
@@ -38,8 +37,6 @@ ARG APP_GID
 ARG TEMURIN_JDK_VERSION
 ARG C3_VERSION
 ARG CONFLUENT_PACKAGES_REPO
-
-COPY --from=build-utilities /go/bin/package_dedupe /usr/local/bin/package_dedupe
 
 RUN printf "[temurin-jre] \n\
 name=temurin-jre \n\
@@ -62,8 +59,6 @@ RUN echo "===> Installing Temurin JRE and Control Center Next Gen..." \
        "temurin-25-jre${TEMURIN_JDK_VERSION}" \
        "confluent-control-center-next-gen-${C3_VERSION}" \
        shadow-utils \
-    && echo "===> Deduping jars in /microdir ..." \
-    && package_dedupe /microdir/usr/share/java \
     && echo "===> Removing unused services (Prometheus, Alertmanager)..." \
     && rm -f /microdir/lib/systemd/system/prometheus.service \
     && rm -rf /microdir/usr/libexec/confluent-control-center/linux_*/prometheus \
@@ -119,7 +114,6 @@ EXPOSE 9021
 USER root
 
 COPY --from=build-utilities /go/bin/ub /usr/bin/ub
-COPY --from=build-utilities /go/bin/package_dedupe /usr/bin/package_dedupe
 COPY --from=builder /microdir/ /
 
 RUN mkdir -p /etc/confluent/docker /usr/logs /licenses \

--- a/pom.xml
+++ b/pom.xml
@@ -79,12 +79,14 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                 <configuration>
                     <buildArgs>
-                        <UBI_MINIMAL_VERSION>${ubi9-minimal.image.version}</UBI_MINIMAL_VERSION>
+                        <APP_UID>${app.uid}</APP_UID>
+                        <APP_GID>${app.gid}</APP_GID>
+                        <UBI9_VERSION>${ubi9.image.version}</UBI9_VERSION>
                         <UBI_MICRO_VERSION>${ubi9-micro.image.version}</UBI_MICRO_VERSION>
                         <ARCH>${arch.type}</ARCH>
                         <C3_VERSION>${C3_VERSION}</C3_VERSION>
                         <GOLANG_VERSION>${golang.image.version}</GOLANG_VERSION>
-                        <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
+                        <TEMURIN_JDK_VERSION>-${ubi9.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
                         <CP_DOCKER_UTILS_VERSION>${git-repo.cp-docker-utils.tag}</CP_DOCKER_UTILS_VERSION>
                     </buildArgs>
                 </configuration>
@@ -97,12 +99,14 @@
                 <image>
                   <build>
                     <args>
-                      <UBI_MINIMAL_VERSION>${ubi9-minimal.image.version}</UBI_MINIMAL_VERSION>
+                      <APP_UID>${app.uid}</APP_UID>
+                      <APP_GID>${app.gid}</APP_GID>
+                      <UBI9_VERSION>${ubi9.image.version}</UBI9_VERSION>
                       <UBI_MICRO_VERSION>${ubi9-micro.image.version}</UBI_MICRO_VERSION>
                       <ARCH>${arch.type}</ARCH>
                       <C3_VERSION>${C3_VERSION}</C3_VERSION>
                       <GOLANG_VERSION>${golang.image.version}</GOLANG_VERSION>
-                      <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
+                      <TEMURIN_JDK_VERSION>-${ubi9.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
                       <CP_DOCKER_UTILS_VERSION>${git-repo.cp-docker-utils.tag}</CP_DOCKER_UTILS_VERSION>
                     </args>
                   </build>
@@ -151,12 +155,16 @@
         the automation tooling can correctly identify and update them.
         -->
 
+        <!-- App User/Group IDs - can be overridden at build time via -Dapp.uid=<value> -Dapp.gid=<value> -->
+        <app.uid>1000</app.uid>
+        <app.gid>1000</app.gid>
+
         <!-- Base Image Versions -->
-        <ubi9-minimal.image.version>9.7-1775623882</ubi9-minimal.image.version>
+        <ubi9.image.version>9.7-1775623882</ubi9.image.version>
         <ubi9-micro.image.version>9.7-1773894938</ubi9-micro.image.version>
 
         <!-- OS Package Versions -->
-        <ubi9-minimal.temurin-21-jdk.version>21.0.10.0.0.7-0</ubi9-minimal.temurin-21-jdk.version>
+        <ubi9.temurin-21-jdk.version>21.0.10.0.0.7-0</ubi9.temurin-21-jdk.version>
 
         <!-- GitHub Repository Tags -->
         <git-repo.cp-docker-utils.tag>v1.0.10</git-repo.cp-docker-utils.tag>

--- a/pom.xml
+++ b/pom.xml
@@ -160,8 +160,8 @@
         <app.gid>1000</app.gid>
 
         <!-- Base Image Versions -->
-        <ubi9.image.version>9.7-1775623882</ubi9.image.version>
-        <ubi9-micro.image.version>9.7-1773894938</ubi9-micro.image.version>
+        <ubi9.image.version>9.7-1771346757</ubi9.image.version>
+        <ubi9-micro.image.version>9.7-1771346390</ubi9-micro.image.version>
 
         <!-- OS Package Versions -->
         <ubi9.temurin-21-jdk.version>21.0.10.0.0.7-0</ubi9.temurin-21-jdk.version>

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,11 @@
         the automation tooling can correctly identify and update them.
         -->
 
-        <!-- App User/Group IDs - can be overridden at build time via -Dapp.uid=<value> -Dapp.gid=<value> -->
+        <!-- Application User Configuration
+             User and group IDs for the non-root user (appuser) configured in Docker images.
+             These values ensure consistent UID/GID across all container images and multi-stage builds,
+             preventing permission issues when copying files between stages or mounting volumes.
+             Can be overridden at build time via: -Dapp.uid=<value> -Dapp.gid=<value> -->
         <app.uid>1000</app.uid>
         <app.gid>1000</app.gid>
 

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
                         <APP_UID>${app.uid}</APP_UID>
                         <APP_GID>${app.gid}</APP_GID>
                         <UBI9_VERSION>${ubi9.image.version}</UBI9_VERSION>
+                        <UBI_MINIMAL_VERSION>${ubi9-minimal.image.version}</UBI_MINIMAL_VERSION>
                         <UBI_MICRO_VERSION>${ubi9-micro.image.version}</UBI_MICRO_VERSION>
                         <ARCH>${arch.type}</ARCH>
                         <C3_VERSION>${C3_VERSION}</C3_VERSION>
@@ -102,6 +103,7 @@
                       <APP_UID>${app.uid}</APP_UID>
                       <APP_GID>${app.gid}</APP_GID>
                       <UBI9_VERSION>${ubi9.image.version}</UBI9_VERSION>
+                      <UBI_MINIMAL_VERSION>${ubi9-minimal.image.version}</UBI_MINIMAL_VERSION>
                       <UBI_MICRO_VERSION>${ubi9-micro.image.version}</UBI_MICRO_VERSION>
                       <ARCH>${arch.type}</ARCH>
                       <C3_VERSION>${C3_VERSION}</C3_VERSION>
@@ -165,6 +167,7 @@
 
         <!-- Base Image Versions -->
         <ubi9.image.version>9.7-1771346757</ubi9.image.version>
+        <ubi9-minimal.image.version>9.7-1778562320</ubi9-minimal.image.version>
         <ubi9-micro.image.version>9.7-1778461406</ubi9-micro.image.version>
 
         <!-- OS Package Versions -->

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -13,49 +13,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG UBI_MINIMAL_VERSION
+ARG UBI9_VERSION
 ARG UBI_MICRO_VERSION
 
-FROM registry.access.redhat.com/ubi9-minimal:${UBI_MINIMAL_VERSION} as builder
-
-ARG PROJECT_VERSION
-ARG ARTIFACT_ID
-ARG GIT_COMMIT
-
-
-ENV COMPONENT=control-center-next-gen
-ENV OLD_COMPONENT_NAME=control-center
-ENV CONTROL_CENTER_DATA_DIR=/var/lib/confluent-${COMPONENT}
-ENV CONTROL_CENTER_CONFIG_DIR=/etc/confluent-${OLD_COMPONENT_NAME}
+# Stage 1: Install packages to /microdir using full ubi9 with dnf
+FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} AS builder
 
 ARG C3_VERSION
 ARG CONFLUENT_PACKAGES_REPO
-ARG CONFLUENT_PLATFORM_LABEL
 
-USER root
-
-RUN echo "===> Installing ${COMPONENT}..." \
-    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
+RUN rpm --import "${CONFLUENT_PACKAGES_REPO}/archive.key" \
     && printf "[Confluent] \n\
 name=Confluent repository \n\
 baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && microdnf install -y confluent-${COMPONENT}-${C3_VERSION} \
-    && microdnf install -y ca-certificates \
-    && echo "===> Creating appuser..." \
-    && useradd --no-log-init --create-home --shell /bin/bash appuser \
-    && echo "===> Cleaning up ..."  \
-    && microdnf clean all \
-    && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
-    && echo "===> Setting up ${COMPONENT} dirs" \
-    && mkdir -p "${CONTROL_CENTER_DATA_DIR}" \
-    && chown appuser:root -R "${CONTROL_CENTER_DATA_DIR}" \
-    && chown appuser:root -R "${CONTROL_CENTER_CONFIG_DIR}" \
-    && chmod -R ug+w "${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"
+    && mkdir -p /microdir
 
-FROM registry.access.redhat.com/ubi9/ubi-micro:${UBI_MICRO_VERSION}
+RUN echo "===> Installing control-center-next-gen..." \
+    && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs \
+       "confluent-control-center-next-gen-${C3_VERSION}" \
+       ca-certificates \
+    && echo "===> Cleaning up ..." \
+    && dnf --installroot=/microdir clean all \
+    && rm -rf /microdir/var/cache/* /microdir/var/log/dnf* /microdir/var/log/yum.* /microdir/tmp/* \
+    && rm /etc/yum.repos.d/confluent.repo \
+    && rm -rf /microdir/dev/* /microdir/proc/* /microdir/sys/*
+
+
+# Stage 2: Final image using ubi9-micro
+FROM registry.access.redhat.com/ubi9-micro:${UBI_MICRO_VERSION}
+
 WORKDIR /app
 USER root
 
@@ -63,8 +52,7 @@ ARG ARCH
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 ARG GIT_COMMIT
-
-# Update package list and install essential packages
+ARG BUILD_NUMBER=-1
 
 LABEL maintainer="partner-support@confluent.io"
 LABEL vendor="Confluent"
@@ -75,20 +63,18 @@ LABEL summary="Prometheus is a monitoring system and time series database, used 
 LABEL description="Prometheus is a monitoring system and time series database, used as backend for Next Gen C3"
 LABEL io.confluent.docker=true
 LABEL io.confluent.docker.git.id=$GIT_COMMIT
-ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 LABEL io.confluent.docker.git.repo="confluentinc/control-center-images"
 
 RUN mkdir -p /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus && \
     mkdir -p /etc/confluent-control-center
 
-
-COPY --from=builder /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/ /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/
-COPY --from=builder /etc/confluent-control-center/ /etc/confluent-control-center/
-COPY --from=builder /usr/bin/prometheus-start /usr/bin/prometheus-start
-COPY --from=builder /usr/bin/prometheus-stop /usr/bin/prometheus-stop
-COPY --from=builder /etc/pki/ca-trust /etc/pki/ca-trust
-COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+COPY --from=builder /microdir/usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/ /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/
+COPY --from=builder /microdir/etc/confluent-control-center/ /etc/confluent-control-center/
+COPY --from=builder /microdir/usr/bin/prometheus-start /usr/bin/prometheus-start
+COPY --from=builder /microdir/usr/bin/prometheus-stop /usr/bin/prometheus-stop
+COPY --from=builder /microdir/etc/pki/ca-trust /etc/pki/ca-trust
+COPY --from=builder /microdir/etc/ssl/certs /etc/ssl/certs
 
 EXPOSE 9090
 
@@ -97,7 +83,6 @@ COPY license.txt /licenses/
 
 RUN chmod +x /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/prometheus-${ARCH#.}
 WORKDIR /usr/bin
-
 
 RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
     mkdir -p /home/appuser && \
@@ -116,5 +101,5 @@ RUN mkdir -p /var/lib/confluent/control-center/prometheus/data && \
 
 USER appuser
 
-VOLUME     [ "/var/lib/confluent/control-center/prometheus/data" ]
+VOLUME [ "/var/lib/confluent/control-center/prometheus/data" ]
 ENTRYPOINT ["prometheus-start"]

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -45,8 +45,7 @@ baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && dnf install -y --installroot=/microdir --releasever=9 confluent-${COMPONENT}-${C3_VERSION} \
-    && dnf install -y --installroot=/microdir --releasever=9 ca-certificates \
+    && dnf install -y --installroot=/microdir --releasever=9 confluent-${COMPONENT}-${C3_VERSION} ca-certificates \
     && echo "===> Creating appuser..." \
     && useradd --no-log-init --create-home --shell /bin/bash appuser \
     && echo "===> Cleaning up ..."  \

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -16,10 +16,10 @@
 ARG APP_UID=1000
 ARG APP_GID=1000
 
-ARG UBI_MINIMAL_VERSION
+ARG UBI9_VERSION
 ARG UBI_MICRO_VERSION
 
-FROM registry.access.redhat.com/ubi9-minimal:${UBI_MINIMAL_VERSION} as builder
+FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} as builder
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
@@ -45,18 +45,18 @@ baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && microdnf install -y confluent-${COMPONENT}-${C3_VERSION} \
-    && microdnf install -y ca-certificates \
+    && dnf install -y --installroot=/microdir --releasever=9 confluent-${COMPONENT}-${C3_VERSION} \
+    && dnf install -y --installroot=/microdir --releasever=9 ca-certificates \
     && echo "===> Creating appuser..." \
     && useradd --no-log-init --create-home --shell /bin/bash appuser \
     && echo "===> Cleaning up ..."  \
-    && microdnf clean all \
+    && dnf --installroot=/microdir clean all \
     && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
     && echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p "${CONTROL_CENTER_DATA_DIR}" \
     && chown appuser:root -R "${CONTROL_CENTER_DATA_DIR}" \
-    && chown appuser:root -R "${CONTROL_CENTER_CONFIG_DIR}" \
-    && chmod -R ug+w "${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"
+    && chown appuser:root -R "/microdir${CONTROL_CENTER_CONFIG_DIR}" \
+    && chmod -R ug+w "/microdir${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"
 
 FROM registry.access.redhat.com/ubi9/ubi-micro:${UBI_MICRO_VERSION}
 WORKDIR /app
@@ -91,12 +91,12 @@ RUN mkdir -p /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus &&
     mkdir -p /etc/confluent-control-center
 
 
-COPY --from=builder /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/ /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/
-COPY --from=builder /etc/confluent-control-center/ /etc/confluent-control-center/
-COPY --from=builder /usr/bin/prometheus-start /usr/bin/prometheus-start
-COPY --from=builder /usr/bin/prometheus-stop /usr/bin/prometheus-stop
-COPY --from=builder /etc/pki/ca-trust /etc/pki/ca-trust
-COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+COPY --from=builder /microdir/usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/ /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/
+COPY --from=builder /microdir/etc/confluent-control-center/ /etc/confluent-control-center/
+COPY --from=builder /microdir/usr/bin/prometheus-start /usr/bin/prometheus-start
+COPY --from=builder /microdir/usr/bin/prometheus-stop /usr/bin/prometheus-stop
+COPY --from=builder /microdir/etc/pki/ca-trust /etc/pki/ca-trust
+COPY --from=builder /microdir/etc/ssl/certs /etc/ssl/certs
 
 EXPOSE 9090
 

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ARG APP_UID=1000
+ARG APP_GID=1000
+
 ARG UBI_MINIMAL_VERSION
 ARG UBI_MICRO_VERSION
 
@@ -59,10 +62,15 @@ FROM registry.access.redhat.com/ubi9/ubi-micro:${UBI_MICRO_VERSION}
 WORKDIR /app
 USER root
 
+ARG APP_UID
+ARG APP_GID
 ARG ARCH
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 ARG GIT_COMMIT
+
+ENV APP_UID=${APP_UID}
+ENV APP_GID=${APP_GID}
 
 # Update package list and install essential packages
 
@@ -99,9 +107,10 @@ RUN chmod +x /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/pr
 WORKDIR /usr/bin
 
 
-RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
+RUN echo "appuser:x:${APP_UID}:${APP_GID}::/home/appuser:/bin/sh" >> /etc/passwd && \
+    echo "appuser:x:${APP_GID}:" >> /etc/group && \
     mkdir -p /home/appuser && \
-    chown 1000:1000 /home/appuser
+    chown ${APP_UID}:${APP_GID} /home/appuser
 
 ENV EXE_PATH="/usr/libexec/confluent-control-center"
 
@@ -112,9 +121,9 @@ ENV EXE_PATH="/usr/libexec/confluent-control-center"
 ## Security Practice: Adheres to the principle of least privilege.
 RUN mkdir -p /var/lib/confluent/control-center/prometheus/data && \
     mkdir -p /var/log/confluent/control-center && \
-    chown -R 1000:1000 /etc/confluent-control-center /var/lib/confluent/control-center/prometheus/data /var/log/confluent/control-center
+    chown -R ${APP_UID}:${APP_GID} /etc/confluent-control-center /var/lib/confluent/control-center/prometheus/data /var/log/confluent/control-center
 
-USER appuser
+USER ${APP_UID}
 
 VOLUME     [ "/var/lib/confluent/control-center/prometheus/data" ]
 ENTRYPOINT ["prometheus-start"]

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -101,5 +101,5 @@ RUN mkdir -p /var/lib/confluent/control-center/prometheus/data && \
 
 USER appuser
 
-VOLUME [ "/var/lib/confluent/control-center/prometheus/data" ]
+VOLUME     [ "/var/lib/confluent/control-center/prometheus/data" ]
 ENTRYPOINT ["prometheus-start"]

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG APP_UID=1000
-ARG APP_GID=1000
-
 ARG UBI_MINIMAL_VERSION
 ARG UBI_MICRO_VERSION
 
@@ -62,15 +59,10 @@ FROM registry.access.redhat.com/ubi9/ubi-micro:${UBI_MICRO_VERSION}
 WORKDIR /app
 USER root
 
-ARG APP_UID
-ARG APP_GID
 ARG ARCH
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 ARG GIT_COMMIT
-
-ENV APP_UID=${APP_UID}
-ENV APP_GID=${APP_GID}
 
 # Update package list and install essential packages
 
@@ -107,10 +99,9 @@ RUN chmod +x /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/pr
 WORKDIR /usr/bin
 
 
-RUN echo "appuser:x:${APP_UID}:${APP_GID}::/home/appuser:/bin/sh" >> /etc/passwd && \
-    echo "appuser:x:${APP_GID}:" >> /etc/group && \
+RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
     mkdir -p /home/appuser && \
-    chown ${APP_UID}:${APP_GID} /home/appuser
+    chown 1000:1000 /home/appuser
 
 ENV EXE_PATH="/usr/libexec/confluent-control-center"
 
@@ -121,9 +112,9 @@ ENV EXE_PATH="/usr/libexec/confluent-control-center"
 ## Security Practice: Adheres to the principle of least privilege.
 RUN mkdir -p /var/lib/confluent/control-center/prometheus/data && \
     mkdir -p /var/log/confluent/control-center && \
-    chown -R ${APP_UID}:${APP_GID} /etc/confluent-control-center /var/lib/confluent/control-center/prometheus/data /var/log/confluent/control-center
+    chown -R 1000:1000 /etc/confluent-control-center /var/lib/confluent/control-center/prometheus/data /var/log/confluent/control-center
 
-USER ${APP_UID}
+USER appuser
 
 VOLUME     [ "/var/lib/confluent/control-center/prometheus/data" ]
 ENTRYPOINT ["prometheus-start"]

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -13,38 +13,49 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG UBI9_VERSION
+ARG UBI_MINIMAL_VERSION
 ARG UBI_MICRO_VERSION
 
-# Stage 1: Install packages to /microdir using full ubi9 with dnf
-FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} AS builder
+FROM registry.access.redhat.com/ubi9-minimal:${UBI_MINIMAL_VERSION} as builder
+
+ARG PROJECT_VERSION
+ARG ARTIFACT_ID
+ARG GIT_COMMIT
+
+
+ENV COMPONENT=control-center-next-gen
+ENV OLD_COMPONENT_NAME=control-center
+ENV CONTROL_CENTER_DATA_DIR=/var/lib/confluent-${COMPONENT}
+ENV CONTROL_CENTER_CONFIG_DIR=/etc/confluent-${OLD_COMPONENT_NAME}
 
 ARG C3_VERSION
 ARG CONFLUENT_PACKAGES_REPO
+ARG CONFLUENT_PLATFORM_LABEL
 
-RUN rpm --import "${CONFLUENT_PACKAGES_REPO}/archive.key" \
+USER root
+
+RUN echo "===> Installing ${COMPONENT}..." \
+    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
     && printf "[Confluent] \n\
 name=Confluent repository \n\
 baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && mkdir -p /microdir
+    && microdnf install -y confluent-${COMPONENT}-${C3_VERSION} \
+    && microdnf install -y ca-certificates \
+    && echo "===> Creating appuser..." \
+    && useradd --no-log-init --create-home --shell /bin/bash appuser \
+    && echo "===> Cleaning up ..."  \
+    && microdnf clean all \
+    && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
+    && echo "===> Setting up ${COMPONENT} dirs" \
+    && mkdir -p "${CONTROL_CENTER_DATA_DIR}" \
+    && chown appuser:root -R "${CONTROL_CENTER_DATA_DIR}" \
+    && chown appuser:root -R "${CONTROL_CENTER_CONFIG_DIR}" \
+    && chmod -R ug+w "${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"
 
-RUN echo "===> Installing control-center-next-gen..." \
-    && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs \
-       "confluent-control-center-next-gen-${C3_VERSION}" \
-       ca-certificates \
-    && echo "===> Cleaning up ..." \
-    && dnf --installroot=/microdir clean all \
-    && rm -rf /microdir/var/cache/* /microdir/var/log/dnf* /microdir/var/log/yum.* /microdir/tmp/* \
-    && rm /etc/yum.repos.d/confluent.repo \
-    && rm -rf /microdir/dev/* /microdir/proc/* /microdir/sys/*
-
-
-# Stage 2: Final image using ubi9-micro
-FROM registry.access.redhat.com/ubi9-micro:${UBI_MICRO_VERSION}
-
+FROM registry.access.redhat.com/ubi9/ubi-micro:${UBI_MICRO_VERSION}
 WORKDIR /app
 USER root
 
@@ -52,7 +63,8 @@ ARG ARCH
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 ARG GIT_COMMIT
-ARG BUILD_NUMBER=-1
+
+# Update package list and install essential packages
 
 LABEL maintainer="partner-support@confluent.io"
 LABEL vendor="Confluent"
@@ -63,18 +75,20 @@ LABEL summary="Prometheus is a monitoring system and time series database, used 
 LABEL description="Prometheus is a monitoring system and time series database, used as backend for Next Gen C3"
 LABEL io.confluent.docker=true
 LABEL io.confluent.docker.git.id=$GIT_COMMIT
+ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 LABEL io.confluent.docker.git.repo="confluentinc/control-center-images"
 
 RUN mkdir -p /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus && \
     mkdir -p /etc/confluent-control-center
 
-COPY --from=builder /microdir/usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/ /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/
-COPY --from=builder /microdir/etc/confluent-control-center/ /etc/confluent-control-center/
-COPY --from=builder /microdir/usr/bin/prometheus-start /usr/bin/prometheus-start
-COPY --from=builder /microdir/usr/bin/prometheus-stop /usr/bin/prometheus-stop
-COPY --from=builder /microdir/etc/pki/ca-trust /etc/pki/ca-trust
-COPY --from=builder /microdir/etc/ssl/certs /etc/ssl/certs
+
+COPY --from=builder /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/ /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/
+COPY --from=builder /etc/confluent-control-center/ /etc/confluent-control-center/
+COPY --from=builder /usr/bin/prometheus-start /usr/bin/prometheus-start
+COPY --from=builder /usr/bin/prometheus-stop /usr/bin/prometheus-stop
+COPY --from=builder /etc/pki/ca-trust /etc/pki/ca-trust
+COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 
 EXPOSE 9090
 
@@ -83,6 +97,7 @@ COPY license.txt /licenses/
 
 RUN chmod +x /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/prometheus-${ARCH#.}
 WORKDIR /usr/bin
+
 
 RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
     mkdir -p /home/appuser && \

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -19,7 +19,7 @@ ARG APP_GID=1000
 ARG UBI9_VERSION
 ARG UBI_MICRO_VERSION
 
-FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} as builder
+FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} AS builder
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
@@ -38,14 +38,14 @@ ARG CONFLUENT_PLATFORM_LABEL
 USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
-    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
+    && rpm --import "${CONFLUENT_PACKAGES_REPO}/archive.key" \
     && printf "[Confluent] \n\
 name=Confluent repository \n\
 baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && dnf install -y --installroot=/microdir --releasever=9 confluent-${COMPONENT}-${C3_VERSION} ca-certificates \
+    && dnf install -y --installroot=/microdir --releasever=9 "confluent-${COMPONENT}-${C3_VERSION}" ca-certificates \
     && echo "===> Creating appuser..." \
     && useradd --no-log-init --create-home --shell /bin/bash appuser \
     && echo "===> Cleaning up ..."  \
@@ -109,7 +109,7 @@ WORKDIR /usr/bin
 RUN echo "appuser:x:${APP_UID}:${APP_GID}::/home/appuser:/bin/sh" >> /etc/passwd && \
     echo "appuser:x:${APP_GID}:" >> /etc/group && \
     mkdir -p /home/appuser && \
-    chown ${APP_UID}:${APP_GID} /home/appuser
+    chown "${APP_UID}:${APP_GID}" /home/appuser
 
 ENV EXE_PATH="/usr/libexec/confluent-control-center"
 
@@ -120,7 +120,7 @@ ENV EXE_PATH="/usr/libexec/confluent-control-center"
 ## Security Practice: Adheres to the principle of least privilege.
 RUN mkdir -p /var/lib/confluent/control-center/prometheus/data && \
     mkdir -p /var/log/confluent/control-center && \
-    chown -R ${APP_UID}:${APP_GID} /etc/confluent-control-center /var/lib/confluent/control-center/prometheus/data /var/log/confluent/control-center
+    chown -R "${APP_UID}:${APP_GID}" /etc/confluent-control-center /var/lib/confluent/control-center/prometheus/data /var/log/confluent/control-center
 
 USER ${APP_UID}
 


### PR DESCRIPTION
## Summary

Migrates the three Docker images in this repo from `ubi9-minimal` → `ubi9-micro` final base. Builder stage switched from `ubi9-minimal + microdnf` to `ubi9 + dnf --installroot=/microdir`. Standardises `APP_UID`/`APP_GID` parameterisation across all three images.

## What changed per Dockerfile

- **`control-center/Dockerfile.ubi9`** — full migration: 3-stage build (Go builder → ubi9 builder with `dnf --installroot=/microdir` → ubi9-micro final). c3 ships as a single Confluent RPM; package_dedupe dropped. The RPM also contains prometheus + alertmanager binaries which aren't needed in the c3 image, so they're removed before the COPY (same logic master had, just on `/microdir` paths).
- **`alertmanager/Dockerfile.ubi9`** — final base was already `ubi9-micro` in master. Minimal diff: builder switched from `ubi9-minimal+microdnf` to `ubi9+dnf --installroot=/microdir`; selective `COPY --from=builder /usr/...` lines have their source paths prefixed with `/microdir/`. Everything else (USER root, ENV vars, useradd appuser, mkdir/chown/chmod, /etc/passwd echo, etc.) is left exactly as in master.
- **`prometheus/Dockerfile.ubi9`** — same minimal-diff treatment as alertmanager.

## Why APP_UID/APP_GID parameterisation

ubi9-micro has no `useradd`, so on c3 the user is created in the ubi9 builder stage via `chroot useradd -u ${APP_UID}` and copied across. Parameterising via build args matches the org-wide common-docker convention and lets restricted environments override at build time with `-Dapp.uid=N -Dapp.gid=N`.

For alertmanager / prometheus the appuser is still created in the final stage via `echo "appuser:x:${APP_UID}:${APP_GID}..." >> /etc/passwd` (same shape as master, only the literals are now parameterised) — applied for org-wide consistency.

> _Quoted from `common-docker/pom.xml`_: "These values ensure consistent UID/GID across all container images and multi-stage builds, preventing permission issues when copying files between stages or mounting volumes."

## Test plan

- [ ] CI build passes (AMD64 + ARM64)
- [ ] cp-enterprise-control-center-next-gen image starts, listens on 9021, runs as non-root `${APP_UID}`
- [ ] alertmanager image starts, listens on 9093, runs as non-root `${APP_UID}`
- [ ] prometheus image starts, listens on 9090, runs as non-root `${APP_UID}`
- [ ] RedHat certification pipeline passes for all three images
- [ ] CFK e2e suite validates (CFK-4617 added 8.3 support)
