### PR TITLE
CPBR-3687 | Update JDK version to JDK 25

### DIFF
--- a/control-center/Dockerfile.ubi9
+++ b/control-center/Dockerfile.ubi9
@@ -66,7 +66,7 @@ gpgcheck=1 \n\
 gpgkey=https://adoptium.jfrog.io/artifactory/api/gpg/key/public \n\
 " > /etc/yum.repos.d/adoptium.repo \
     && echo "===> Installing Temurin JRE..." \
-    && microdnf install -y temurin-21-jre${TEMURIN_JDK_VERSION} \
+    && microdnf install -y temurin-25-jre${TEMURIN_JDK_VERSION} \
     && microdnf clean all \
     && echo "===> Creating appuser and directories..." \
     && useradd --no-log-init --create-home --shell /bin/bash appuser \

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
                         <ARCH>${arch.type}</ARCH>
                         <C3_VERSION>${C3_VERSION}</C3_VERSION>
                         <GOLANG_VERSION>${golang.image.version}</GOLANG_VERSION>
-                        <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
+                        <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-25-jdk.version}</TEMURIN_JDK_VERSION>
                         <CP_DOCKER_UTILS_VERSION>${git-repo.cp-docker-utils.tag}</CP_DOCKER_UTILS_VERSION>
                     </buildArgs>
                 </configuration>
@@ -102,7 +102,7 @@
                       <ARCH>${arch.type}</ARCH>
                       <C3_VERSION>${C3_VERSION}</C3_VERSION>
                       <GOLANG_VERSION>${golang.image.version}</GOLANG_VERSION>
-                      <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
+                      <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-25-jdk.version}</TEMURIN_JDK_VERSION>
                       <CP_DOCKER_UTILS_VERSION>${git-repo.cp-docker-utils.tag}</CP_DOCKER_UTILS_VERSION>
                     </args>
                   </build>
@@ -156,7 +156,7 @@
         <ubi9-micro.image.version>9.7-1773894938</ubi9-micro.image.version>
 
         <!-- OS Package Versions -->
-        <ubi9-minimal.temurin-21-jdk.version>21.0.10.0.0.7-0</ubi9-minimal.temurin-21-jdk.version>
+        <ubi9-minimal.temurin-25-jdk.version>25.0.2.0.0.10-0</ubi9-minimal.temurin-25-jdk.version>
 
         <!-- GitHub Repository Tags -->
         <git-repo.cp-docker-utils.tag>v1.0.10</git-repo.cp-docker-utils.tag>


### PR DESCRIPTION
### Description
AK added support for Java 25 starting 4.2. Following that CP is adding support for java 25 for CP components starting CP 8.3. This PR updates the control-center-next-gen images to use JDK 25 in the C3 dockerfile. This change follows the updates done to common-docker images for JDK 25 https://github.com/confluentinc/common-docker/pull/1588

### JIRA Ticket
https://confluentinc.atlassian.net/browse/CPBR-3687

### Changes Made
Since CP 8.3 will be shipped with C3 2.6(currently master), this change updates the Java version used for docker images of C3 to JDK 25. 
- Updates `temurin-25-jdk.version` to `25.0.2.0.0.10` and updates dockerfile references to JDK 25

---

## Mandatory Testing ⚠️

### Image built with the changes

<img width="1728" height="1043" alt="Screenshot 2026-04-30 at 11 17 07 AM" src="https://github.com/user-attachments/assets/6de12484-cfff-45ef-ba45-fbad756e95d5" />

### Image running on cp-all-in-one

<img width="1728" height="1085" alt="Screenshot 2026-04-30 at 11 17 47 AM" src="https://github.com/user-attachments/assets/ef50a69a-73a5-4941-a469-49d7d21c65d2" />

### C3 UI

<img width="1728" height="1032" alt="Screenshot 2026-04-30 at 11 16 25 AM" src="https://github.com/user-attachments/assets/e1c97c53-7496-4134-897e-a78ac4f12597" />


## Testing Checklist

- [X] Semaphore job completed successfully and image URL identified
- [NA] Docker compose file updated with new image
- [X] Control Center starts up successfully
- [X] Control Center UI is accessible and functional
- [X] All required screenshots provided above

