### PR TITLE
CPBR-3628: Switch QEMU binfmt init to tonistiigi/binfmt for s390x

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -362,7 +362,7 @@ blocks:
             - export DOCKER_DEV_FULL_IMAGES=$DOCKER_DEV_REGISTRY${DOCKER_REPOS// /:$DOCKER_DEV_TAG$OS_TAG $DOCKER_DEV_REGISTRY}:$DOCKER_DEV_TAG$OS_TAG
             - export S390X_DOCKER_DEV_FULL_IMAGES=${DOCKER_DEV_FULL_IMAGES// /$S390X_ARCH }$S390X_ARCH
             # Register QEMU binfmt handlers for s390x cross-compilation
-            - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+            - docker run --rm --privileged tonistiigi/binfmt --install s390x
             - ci-tools ci-update-version
             - export OS_PACKAGES_URL=$(echo "$PACKAGES_URL" | sed "s/PACKAGE_TYPE/rpm/g")
             - export PACKAGING_BUILD_ARGS="$PACKAGING_BUILD_ARGS -DCONFLUENT_PACKAGES_REPO=$OS_PACKAGES_URL"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -158,7 +158,7 @@ blocks:
             - export DOCKER_DEV_FULL_IMAGES=$DOCKER_DEV_REGISTRY${DOCKER_REPOS// /:$DOCKER_DEV_TAG$OS_TAG $DOCKER_DEV_REGISTRY}:$DOCKER_DEV_TAG$OS_TAG
             - export S390X_DOCKER_DEV_FULL_IMAGES=${DOCKER_DEV_FULL_IMAGES// /$S390X_ARCH }$S390X_ARCH
             # Register QEMU binfmt handlers for s390x cross-compilation
-            - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+            - docker run --rm --privileged tonistiigi/binfmt --install s390x
             - ci-tools ci-update-version
             - export OS_PACKAGES_URL=$(echo "$PACKAGES_URL" | sed "s/PACKAGE_TYPE/rpm/g")
             - export PACKAGING_BUILD_ARGS="$PACKAGING_BUILD_ARGS -DCONFLUENT_PACKAGES_REPO=$OS_PACKAGES_URL"


### PR DESCRIPTION
Update QEMU binfmt registration to use `tonistiigi/binfmt --install s390x` to keep it consistent with the CP image build process (kafka-images, cp-build-release).