### PR TITLE
MMA-17737: add cp-all-in-one verification block to PR pipeline

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -1,8 +1,3 @@
-# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
-# template and configurations in service.yml.
-# Any modifications made to ths file will be overwritten by the generated content in nightly runs.
-# For more information, please refer to the page:
-# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
 version: v1.0
 name: build-test-release
 agent:

--- a/.semaphore/cp_dockerfile_promote.yml
+++ b/.semaphore/cp_dockerfile_promote.yml
@@ -1,8 +1,3 @@
-# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
-# template and configurations in service.yml.
-# Any modifications made to ths file will be overwritten by the generated content in nightly runs.
-# For more information, please refer to the page:
-# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
 version: v1.0
 name: build-test-release
 agent:

--- a/.semaphore/scripts/verify-cp-all-in-one.sh
+++ b/.semaphore/scripts/verify-cp-all-in-one.sh
@@ -52,6 +52,31 @@ resolve_branch() {
   fi
 }
 
+# Patch an image ref in docker-compose.yml from the upstream public repo to
+# the PR's dev ECR URL. Fails loudly (exit 1) if either:
+#   - the expected upstream image ref isn't present in the compose file
+#     (cp-all-in-one upstream may have renamed/removed the service)
+#   - the substitution doesn't land (the regex matched something we didn't
+#     expect, or sed silently no-op'd)
+# Without these asserts, a non-matching sed would silently leave the
+# upstream image in place and the smoke test would falsely pass against
+# images this PR didn't build.
+patch_image() {
+  local image_repo="$1"          # e.g. "confluentinc/cp-enterprise-prometheus"
+  local replacement_url="$2"     # full dev ECR URL with tag
+
+  if ! grep -qE "^[[:space:]]*image:[[:space:]]*${image_repo}:" docker-compose.yml; then
+    echo "ERROR: docker-compose.yml has no image ref for '${image_repo}'." >&2
+    echo "       cp-all-in-one upstream may have renamed or removed this service." >&2
+    exit 1
+  fi
+  sed -i -E "s|image:[[:space:]]*${image_repo}:[^[:space:]]+|image: ${replacement_url}|g" docker-compose.yml
+  if ! grep -qF "${replacement_url}" docker-compose.yml; then
+    echo "ERROR: sed substitution for '${image_repo}' did not land in docker-compose.yml." >&2
+    exit 1
+  fi
+}
+
 cmd_up() {
   local repo_root="$PWD"
   local cp_version branch
@@ -77,9 +102,9 @@ cmd_up() {
   git clone --depth 1 -b "$branch" "$CP_ALL_IN_ONE_REPO" "$AIO_DIR"
   cd "$AIO_COMPOSE_DIR"
 
-  sed -i -E "s|image:[[:space:]]*confluentinc/cp-enterprise-control-center-next-gen:[^[:space:]]+|image: ${dev_c3}|g" docker-compose.yml
-  sed -i -E "s|image:[[:space:]]*confluentinc/cp-enterprise-prometheus:[^[:space:]]+|image: ${dev_prom}|g" docker-compose.yml
-  sed -i -E "s|image:[[:space:]]*confluentinc/cp-enterprise-alertmanager:[^[:space:]]+|image: ${dev_am}|g" docker-compose.yml
+  patch_image "confluentinc/cp-enterprise-control-center-next-gen" "$dev_c3"
+  patch_image "confluentinc/cp-enterprise-prometheus"               "$dev_prom"
+  patch_image "confluentinc/cp-enterprise-alertmanager"             "$dev_am"
 
   echo "Patched image refs:"
   grep -E "^[[:space:]]*image:" docker-compose.yml

--- a/.semaphore/scripts/verify-cp-all-in-one.sh
+++ b/.semaphore/scripts/verify-cp-all-in-one.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# Smoke-test the PR-built docker images by booting cp-all-in-one with them and
+# polling control-center, prometheus, and alertmanager for HTTP 200.
+#
+# Addresses MMA-17737 / INC-6655 by automating the manual screenshot step in
+# .github/PULL_REQUEST_TEMPLATE.md.
+#
+# Usage:
+#   verify-cp-all-in-one.sh up    # clone, sed-patch, compose up, poll healthchecks
+#   verify-cp-all-in-one.sh down  # tear down (run in always-epilogue) — dumps
+#                                 # ps + per-service logs, then `compose down -v`.
+#
+# Required env vars (exported by the global Semaphore prologue):
+#   DOCKER_DEV_REGISTRY  e.g. 519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/dev/
+#   DOCKER_DEV_TAG       e.g. dev-2.3.x-327c2d06
+#   AMD_ARCH             e.g. .amd64
+
+set -euo pipefail
+
+AIO_DIR=/tmp/cp-all-in-one
+AIO_COMPOSE_DIR="$AIO_DIR/cp-all-in-one"
+CP_ALL_IN_ONE_REPO=https://github.com/confluentinc/cp-all-in-one.git
+HEALTH_TIMEOUT_TRIES=60
+HEALTH_TIMEOUT_SLEEP=10
+
+# Derive the CP version from this repo's pom.xml parent <version>.
+# Example: "[8.0.4-0, 8.0.5-0)"  ->  "8.0.4"
+derive_cp_version() {
+  local pom="$1"
+  local parent_version
+  parent_version=$(awk '/<parent>/,/<\/parent>/' "$pom" \
+    | sed -nE 's|.*<version>([^<]+)</version>.*|\1|p' \
+    | head -1)
+  echo "$parent_version" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1
+}
+
+# Resolve a cp-all-in-one branch for a given CP version.
+# Preference: "<cp>-post" > "<cp major.minor>.x" > "master".
+resolve_branch() {
+  local cp_version="$1"
+  local cp_post="${cp_version}-post"
+  local cp_x
+  cp_x="$(echo "$cp_version" | grep -oE '^[0-9]+\.[0-9]+').x"
+
+  if git ls-remote --exit-code --heads "$CP_ALL_IN_ONE_REPO" "$cp_post" >/dev/null 2>&1; then
+    echo "$cp_post"
+  elif git ls-remote --exit-code --heads "$CP_ALL_IN_ONE_REPO" "$cp_x" >/dev/null 2>&1; then
+    echo "$cp_x"
+  else
+    echo "master"
+  fi
+}
+
+cmd_up() {
+  local repo_root="$PWD"
+  local cp_version branch
+  cp_version=$(derive_cp_version "$repo_root/pom.xml")
+  if [ -z "$cp_version" ]; then
+    echo "Could not derive CP version from $repo_root/pom.xml parent.version"
+    exit 1
+  fi
+
+  branch=$(resolve_branch "$cp_version")
+  echo "Using cp-all-in-one branch: $branch (CP_VERSION=$cp_version, from pom.xml parent.version)"
+
+  local arch_tag="-ubi9${AMD_ARCH}"
+  local dev_c3="${DOCKER_DEV_REGISTRY}confluentinc/cp-enterprise-control-center-next-gen:${DOCKER_DEV_TAG}${arch_tag}"
+  local dev_prom="${DOCKER_DEV_REGISTRY}confluentinc/cp-enterprise-prometheus:${DOCKER_DEV_TAG}${arch_tag}"
+  local dev_am="${DOCKER_DEV_REGISTRY}confluentinc/cp-enterprise-alertmanager:${DOCKER_DEV_TAG}${arch_tag}"
+  echo "Using PR-built images:"
+  echo "  C3:   $dev_c3"
+  echo "  PROM: $dev_prom"
+  echo "  AM:   $dev_am"
+
+  rm -rf "$AIO_DIR"
+  git clone --depth 1 -b "$branch" "$CP_ALL_IN_ONE_REPO" "$AIO_DIR"
+  cd "$AIO_COMPOSE_DIR"
+
+  sed -i -E "s|image:[[:space:]]*confluentinc/cp-enterprise-control-center-next-gen:[^[:space:]]+|image: ${dev_c3}|g" docker-compose.yml
+  sed -i -E "s|image:[[:space:]]*confluentinc/cp-enterprise-prometheus:[^[:space:]]+|image: ${dev_prom}|g" docker-compose.yml
+  sed -i -E "s|image:[[:space:]]*confluentinc/cp-enterprise-alertmanager:[^[:space:]]+|image: ${dev_am}|g" docker-compose.yml
+
+  echo "Patched image refs:"
+  grep -E "^[[:space:]]*image:" docker-compose.yml
+
+  docker compose pull
+  docker compose up -d
+
+  echo "Waiting up to $((HEALTH_TIMEOUT_TRIES * HEALTH_TIMEOUT_SLEEP / 60)) minutes for control-center, prometheus, and alertmanager to become healthy..."
+  local healthy=0 c3 prom am
+  for i in $(seq 1 "$HEALTH_TIMEOUT_TRIES"); do
+    c3=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:9021/ || true)
+    prom=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:9090/-/ready || true)
+    am=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:9093/-/ready || true)
+    echo "[try $i] control-center=${c3:-000} prometheus=${prom:-000} alertmanager=${am:-000}"
+    if [ "$c3" = "200" ] && [ "$prom" = "200" ] && [ "$am" = "200" ]; then
+      healthy=1
+      break
+    fi
+    sleep "$HEALTH_TIMEOUT_SLEEP"
+  done
+  if [ "$healthy" != "1" ]; then
+    echo "Verification failed: services did not all become healthy within the timeout."
+    exit 1
+  fi
+  echo "Verification passed: control-center, prometheus, and alertmanager are healthy."
+}
+
+cmd_down() {
+  if [ ! -d "$AIO_COMPOSE_DIR" ]; then
+    echo "cp-all-in-one compose dir not found, nothing to tear down"
+    return 0
+  fi
+  cd "$AIO_COMPOSE_DIR"
+  echo "=== docker compose ps ==="
+  docker compose ps || true
+  echo "=== control-center logs ==="
+  docker compose logs --no-color --tail=300 control-center || true
+  echo "=== prometheus logs ==="
+  docker compose logs --no-color --tail=100 prometheus || true
+  echo "=== alertmanager logs ==="
+  docker compose logs --no-color --tail=100 alertmanager || true
+  docker compose down -v || true
+}
+
+case "${1:-}" in
+  up) cmd_up ;;
+  down) cmd_down ;;
+  *) echo "usage: $0 up|down" >&2; exit 2 ;;
+esac

--- a/.semaphore/scripts/verify-cp-all-in-one.sh
+++ b/.semaphore/scripts/verify-cp-all-in-one.sh
@@ -36,7 +36,10 @@ derive_cp_version() {
 }
 
 # Resolve a cp-all-in-one branch for a given CP version.
-# Preference: "<cp>-post" > "<cp major.minor>.x" > "master".
+# Preference: "<cp>-post" (released-patch pin) > "<cp major.minor>.x" (active-dev).
+# If neither exists, fails loudly (exit 1) rather than silently testing against
+# cp-all-in-one master — testing C3 images against a non-matching CP version
+# would give a misleading verification signal.
 resolve_branch() {
   local cp_version="$1"
   local cp_post="${cp_version}-post"
@@ -48,7 +51,10 @@ resolve_branch() {
   elif git ls-remote --exit-code --heads "$CP_ALL_IN_ONE_REPO" "$cp_x" >/dev/null 2>&1; then
     echo "$cp_x"
   else
-    echo "master"
+    echo "ERROR: Neither '$cp_post' nor '$cp_x' exists on $CP_ALL_IN_ONE_REPO." >&2
+    echo "       Coordinate with cp-all-in-one maintainers to create a branch" >&2
+    echo "       matching CP $cp_version before this PR can be verified." >&2
+    return 1
   fi
 }
 
@@ -86,7 +92,11 @@ cmd_up() {
     exit 1
   fi
 
-  branch=$(resolve_branch "$cp_version")
+  # `set -e` doesn't propagate command-substitution failure into a bare assignment,
+  # so we use `if !` to explicitly catch a non-zero exit from resolve_branch.
+  if ! branch=$(resolve_branch "$cp_version"); then
+    exit 1
+  fi
   echo "Using cp-all-in-one branch: $branch (CP_VERSION=$cp_version, from pom.xml parent.version)"
 
   local arch_tag="-ubi9${AMD_ARCH}"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,8 +1,3 @@
-# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
-# template and configurations in service.yml.
-# Any modifications made to ths file will be overwritten by the generated content in nightly runs.
-# For more information, please refer to the page:
-# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
 version: v1.0
 name: build-test-release
 agent:
@@ -159,6 +154,85 @@ blocks:
             - . publish-test-results
             - artifact push workflow target/test-results
             - artifact push workflow target --destination target-ARM
+  # Automates the manual verification described in .github/PULL_REQUEST_TEMPLATE.md:
+  # boots cp-all-in-one with the PR-built dev images and waits for control-center,
+  # prometheus, and alertmanager to respond healthy. Addresses MMA-17737 / INC-6655.
+  - name: Verify cp-all-in-one Docker Compose
+    dependencies: ["Build, Test, & Scan AMD"]
+    run:
+      when: "pull_request =~ '.*'"
+    task:
+      jobs:
+        - name: cp-all-in-one docker compose smoke test
+          commands:
+            # Derive the matching cp-all-in-one branch from depot's c3_versions.json
+            # using C3_VERSION (hardcoded per branch in the global prologue).
+            # Override by setting CP_ALL_IN_ONE_BRANCH externally (e.g. when re-running
+            # the workflow from the Semaphore UI).
+            - |
+              if [ -z "${CP_ALL_IN_ONE_BRANCH:-}" ]; then
+                C3_KEY="$(echo "$C3_VERSION" | grep -oE '^[0-9]+\.[0-9]+').x"
+                CP_VERSION=$(gh api repos/confluentinc/depot/contents/python/common_tools/data/prod/c3_versions.json \
+                  | jq -r '.content' | base64 -d \
+                  | jq -r --arg v "$C3_KEY" '.[$v]["confluent.version"] // empty' \
+                  | sed -E 's/-cp[0-9]+$//')
+                if [ -n "$CP_VERSION" ]; then
+                  CP_ALL_IN_ONE_BRANCH="${CP_VERSION}-post"
+                  # Fall back to master if the derived branch hasn't been cut yet.
+                  if ! git ls-remote --exit-code --heads https://github.com/confluentinc/cp-all-in-one.git "$CP_ALL_IN_ONE_BRANCH" >/dev/null 2>&1; then
+                    echo "cp-all-in-one branch '$CP_ALL_IN_ONE_BRANCH' not found, falling back to master"
+                    CP_ALL_IN_ONE_BRANCH=master
+                  fi
+                else
+                  echo "No c3_versions.json entry for $C3_KEY, falling back to master"
+                  CP_ALL_IN_ONE_BRANCH=master
+                fi
+                export CP_ALL_IN_ONE_BRANCH
+              fi
+              echo "Using cp-all-in-one branch: $CP_ALL_IN_ONE_BRANCH (C3_VERSION=$C3_VERSION)"
+            - export ARCH_TAG="-ubi9$AMD_ARCH"
+            - export DEV_C3_IMAGE="${DOCKER_DEV_REGISTRY}confluentinc/cp-enterprise-control-center-next-gen:${DOCKER_DEV_TAG}${ARCH_TAG}"
+            - export DEV_PROM_IMAGE="${DOCKER_DEV_REGISTRY}confluentinc/cp-enterprise-prometheus:${DOCKER_DEV_TAG}${ARCH_TAG}"
+            - export DEV_AM_IMAGE="${DOCKER_DEV_REGISTRY}confluentinc/cp-enterprise-alertmanager:${DOCKER_DEV_TAG}${ARCH_TAG}"
+            - echo "Using PR-built images - C3:$DEV_C3_IMAGE PROM:$DEV_PROM_IMAGE AM:$DEV_AM_IMAGE"
+            - export AIO_DIR=/tmp/cp-all-in-one
+            - rm -rf "$AIO_DIR"
+            - git clone --depth 1 -b "$CP_ALL_IN_ONE_BRANCH" https://github.com/confluentinc/cp-all-in-one.git "$AIO_DIR"
+            - cd "$AIO_DIR/cp-all-in-one"
+            - sed -i -E "s|image:[[:space:]]*confluentinc/cp-enterprise-control-center-next-gen:[^[:space:]]+|image: ${DEV_C3_IMAGE}|g" docker-compose.yml
+            - sed -i -E "s|image:[[:space:]]*confluentinc/cp-enterprise-prometheus:[^[:space:]]+|image: ${DEV_PROM_IMAGE}|g" docker-compose.yml
+            - sed -i -E "s|image:[[:space:]]*confluentinc/cp-enterprise-alertmanager:[^[:space:]]+|image: ${DEV_AM_IMAGE}|g" docker-compose.yml
+            - echo "Patched image refs:" && grep -E "^[[:space:]]*image:" docker-compose.yml
+            - docker compose pull control-center prometheus alertmanager
+            - docker compose up -d
+            - |
+              echo "Waiting up to 10 minutes for control-center, prometheus, and alertmanager to become healthy..."
+              healthy=0
+              for i in $(seq 1 60); do
+                c3=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:9021/ || echo 000)
+                prom=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:9090/-/ready || echo 000)
+                am=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:9093/-/ready || echo 000)
+                echo "[try $i] control-center=$c3 prometheus=$prom alertmanager=$am"
+                if [ "$c3" = "200" ] && [ "$prom" = "200" ] && [ "$am" = "200" ]; then
+                  healthy=1
+                  break
+                fi
+                sleep 10
+              done
+              if [ "$healthy" != "1" ]; then
+                echo "Verification failed: services did not all become healthy within 10 minutes."
+                exit 1
+              fi
+              echo "Verification passed: control-center, prometheus, and alertmanager are healthy."
+      epilogue:
+        always:
+          commands:
+            - cd /tmp/cp-all-in-one/cp-all-in-one || true
+            - echo "=== docker compose ps ===" && docker compose ps || true
+            - echo "=== control-center logs ===" && docker compose logs --no-color --tail=300 control-center || true
+            - echo "=== prometheus logs ===" && docker compose logs --no-color --tail=100 prometheus || true
+            - echo "=== alertmanager logs ===" && docker compose logs --no-color --tail=100 alertmanager || true
+            - docker compose down -v || true
 after_pipeline:
   task:
     agent:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -157,6 +157,8 @@ blocks:
   # Automates the manual verification described in .github/PULL_REQUEST_TEMPLATE.md:
   # boots cp-all-in-one with the PR-built dev images and waits for control-center,
   # prometheus, and alertmanager to respond healthy. Addresses MMA-17737 / INC-6655.
+  # Logic lives in .semaphore/scripts/verify-cp-all-in-one.sh so it's easy to
+  # debug, lint, and run locally outside of CI.
   - name: Verify cp-all-in-one Docker Compose
     dependencies: ["Build, Test, & Scan AMD"]
     run:
@@ -165,90 +167,11 @@ blocks:
       jobs:
         - name: cp-all-in-one docker compose smoke test
           commands:
-            # Derive the matching cp-all-in-one branch from depot's c3_versions.json
-            # using C3_VERSION (set per branch in the global prologue by the version-bump bot).
-            #
-            # Resolution order:
-            #   1. Exact C3_VERSION lookup (e.g. "2.3.2") -> CP_VERSION (e.g. "8.0.4")
-            #      Falls back to .x lookup (e.g. "2.3.x") if exact isn't in json.
-            #   2. Prefer "<CP_VERSION>-post" (the released-patch pin) on cp-all-in-one.
-            #   3. Else "<CP major.minor>.x" (active-dev branch for that CP line,
-            #      used when -post hasn't been cut yet but the line is in dev).
-            #   4. Else "master" (last-resort fallback).
-            - |
-              C3_VERSIONS_JSON=$(gh api repos/confluentinc/depot/contents/python/common_tools/data/prod/c3_versions.json \
-                | jq -r '.content' | base64 -d)
-              CP_VERSION=$(echo "$C3_VERSIONS_JSON" \
-                | jq -r --arg v "$C3_VERSION" '.[$v]["confluent.version"] // empty' \
-                | sed -E 's/-cp[0-9]+$//')
-              if [ -z "$CP_VERSION" ]; then
-                C3_KEY="$(echo "$C3_VERSION" | grep -oE '^[0-9]+\.[0-9]+').x"
-                echo "No c3_versions.json entry for exact $C3_VERSION; trying $C3_KEY"
-                CP_VERSION=$(echo "$C3_VERSIONS_JSON" \
-                  | jq -r --arg v "$C3_KEY" '.[$v]["confluent.version"] // empty' \
-                  | sed -E 's/-cp[0-9]+$//')
-              fi
-              if [ -n "$CP_VERSION" ]; then
-                CP_POST_BRANCH="${CP_VERSION}-post"
-                CP_X_BRANCH="$(echo "$CP_VERSION" | grep -oE '^[0-9]+\.[0-9]+').x"
-                if git ls-remote --exit-code --heads https://github.com/confluentinc/cp-all-in-one.git "$CP_POST_BRANCH" >/dev/null 2>&1; then
-                  CP_ALL_IN_ONE_BRANCH="$CP_POST_BRANCH"
-                elif git ls-remote --exit-code --heads https://github.com/confluentinc/cp-all-in-one.git "$CP_X_BRANCH" >/dev/null 2>&1; then
-                  echo "cp-all-in-one '$CP_POST_BRANCH' not cut yet; using active-dev '$CP_X_BRANCH'"
-                  CP_ALL_IN_ONE_BRANCH="$CP_X_BRANCH"
-                else
-                  echo "Neither '$CP_POST_BRANCH' nor '$CP_X_BRANCH' exists; falling back to master"
-                  CP_ALL_IN_ONE_BRANCH=master
-                fi
-              else
-                echo "No c3_versions.json entry for $C3_VERSION; falling back to master"
-                CP_ALL_IN_ONE_BRANCH=master
-              fi
-              export CP_ALL_IN_ONE_BRANCH
-              echo "Using cp-all-in-one branch: $CP_ALL_IN_ONE_BRANCH (C3_VERSION=$C3_VERSION, CP_VERSION=$CP_VERSION)"
-            - export ARCH_TAG="-ubi9$AMD_ARCH"
-            - export DEV_C3_IMAGE="${DOCKER_DEV_REGISTRY}confluentinc/cp-enterprise-control-center-next-gen:${DOCKER_DEV_TAG}${ARCH_TAG}"
-            - export DEV_PROM_IMAGE="${DOCKER_DEV_REGISTRY}confluentinc/cp-enterprise-prometheus:${DOCKER_DEV_TAG}${ARCH_TAG}"
-            - export DEV_AM_IMAGE="${DOCKER_DEV_REGISTRY}confluentinc/cp-enterprise-alertmanager:${DOCKER_DEV_TAG}${ARCH_TAG}"
-            - echo "Using PR-built images - C3:$DEV_C3_IMAGE PROM:$DEV_PROM_IMAGE AM:$DEV_AM_IMAGE"
-            - export AIO_DIR=/tmp/cp-all-in-one
-            - rm -rf "$AIO_DIR"
-            - git clone --depth 1 -b "$CP_ALL_IN_ONE_BRANCH" https://github.com/confluentinc/cp-all-in-one.git "$AIO_DIR"
-            - cd "$AIO_DIR/cp-all-in-one"
-            - 'sed -i -E "s|image:[[:space:]]*confluentinc/cp-enterprise-control-center-next-gen:[^[:space:]]+|image: ${DEV_C3_IMAGE}|g" docker-compose.yml'
-            - 'sed -i -E "s|image:[[:space:]]*confluentinc/cp-enterprise-prometheus:[^[:space:]]+|image: ${DEV_PROM_IMAGE}|g" docker-compose.yml'
-            - 'sed -i -E "s|image:[[:space:]]*confluentinc/cp-enterprise-alertmanager:[^[:space:]]+|image: ${DEV_AM_IMAGE}|g" docker-compose.yml'
-            - echo "Patched image refs:" && grep -E "^[[:space:]]*image:" docker-compose.yml
-            - docker compose pull
-            - docker compose up -d
-            - |
-              echo "Waiting up to 10 minutes for control-center, prometheus, and alertmanager to become healthy..."
-              healthy=0
-              for i in $(seq 1 60); do
-                c3=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:9021/ || echo 000)
-                prom=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:9090/-/ready || echo 000)
-                am=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:9093/-/ready || echo 000)
-                echo "[try $i] control-center=$c3 prometheus=$prom alertmanager=$am"
-                if [ "$c3" = "200" ] && [ "$prom" = "200" ] && [ "$am" = "200" ]; then
-                  healthy=1
-                  break
-                fi
-                sleep 10
-              done
-              if [ "$healthy" != "1" ]; then
-                echo "Verification failed: services did not all become healthy within 10 minutes."
-                exit 1
-              fi
-              echo "Verification passed: control-center, prometheus, and alertmanager are healthy."
+            - .semaphore/scripts/verify-cp-all-in-one.sh up
       epilogue:
         always:
           commands:
-            - cd /tmp/cp-all-in-one/cp-all-in-one || true
-            - echo "=== docker compose ps ===" && docker compose ps || true
-            - echo "=== control-center logs ===" && docker compose logs --no-color --tail=300 control-center || true
-            - echo "=== prometheus logs ===" && docker compose logs --no-color --tail=100 prometheus || true
-            - echo "=== alertmanager logs ===" && docker compose logs --no-color --tail=100 alertmanager || true
-            - docker compose down -v || true
+            - .semaphore/scripts/verify-cp-all-in-one.sh down
 after_pipeline:
   task:
     agent:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -166,30 +166,46 @@ blocks:
         - name: cp-all-in-one docker compose smoke test
           commands:
             # Derive the matching cp-all-in-one branch from depot's c3_versions.json
-            # using C3_VERSION (hardcoded per branch in the global prologue).
-            # Override by setting CP_ALL_IN_ONE_BRANCH externally (e.g. when re-running
-            # the workflow from the Semaphore UI).
+            # using C3_VERSION (set per branch in the global prologue by the version-bump bot).
+            #
+            # Resolution order:
+            #   1. Exact C3_VERSION lookup (e.g. "2.3.2") -> CP_VERSION (e.g. "8.0.4")
+            #      Falls back to .x lookup (e.g. "2.3.x") if exact isn't in json.
+            #   2. Prefer "<CP_VERSION>-post" (the released-patch pin) on cp-all-in-one.
+            #   3. Else "<CP major.minor>.x" (active-dev branch for that CP line,
+            #      used when -post hasn't been cut yet but the line is in dev).
+            #   4. Else "master" (last-resort fallback).
             - |
-              if [ -z "${CP_ALL_IN_ONE_BRANCH:-}" ]; then
+              C3_VERSIONS_JSON=$(gh api repos/confluentinc/depot/contents/python/common_tools/data/prod/c3_versions.json \
+                | jq -r '.content' | base64 -d)
+              CP_VERSION=$(echo "$C3_VERSIONS_JSON" \
+                | jq -r --arg v "$C3_VERSION" '.[$v]["confluent.version"] // empty' \
+                | sed -E 's/-cp[0-9]+$//')
+              if [ -z "$CP_VERSION" ]; then
                 C3_KEY="$(echo "$C3_VERSION" | grep -oE '^[0-9]+\.[0-9]+').x"
-                CP_VERSION=$(gh api repos/confluentinc/depot/contents/python/common_tools/data/prod/c3_versions.json \
-                  | jq -r '.content' | base64 -d \
+                echo "No c3_versions.json entry for exact $C3_VERSION; trying $C3_KEY"
+                CP_VERSION=$(echo "$C3_VERSIONS_JSON" \
                   | jq -r --arg v "$C3_KEY" '.[$v]["confluent.version"] // empty' \
                   | sed -E 's/-cp[0-9]+$//')
-                if [ -n "$CP_VERSION" ]; then
-                  CP_ALL_IN_ONE_BRANCH="${CP_VERSION}-post"
-                  # Fall back to master if the derived branch hasn't been cut yet.
-                  if ! git ls-remote --exit-code --heads https://github.com/confluentinc/cp-all-in-one.git "$CP_ALL_IN_ONE_BRANCH" >/dev/null 2>&1; then
-                    echo "cp-all-in-one branch '$CP_ALL_IN_ONE_BRANCH' not found, falling back to master"
-                    CP_ALL_IN_ONE_BRANCH=master
-                  fi
+              fi
+              if [ -n "$CP_VERSION" ]; then
+                CP_POST_BRANCH="${CP_VERSION}-post"
+                CP_X_BRANCH="$(echo "$CP_VERSION" | grep -oE '^[0-9]+\.[0-9]+').x"
+                if git ls-remote --exit-code --heads https://github.com/confluentinc/cp-all-in-one.git "$CP_POST_BRANCH" >/dev/null 2>&1; then
+                  CP_ALL_IN_ONE_BRANCH="$CP_POST_BRANCH"
+                elif git ls-remote --exit-code --heads https://github.com/confluentinc/cp-all-in-one.git "$CP_X_BRANCH" >/dev/null 2>&1; then
+                  echo "cp-all-in-one '$CP_POST_BRANCH' not cut yet; using active-dev '$CP_X_BRANCH'"
+                  CP_ALL_IN_ONE_BRANCH="$CP_X_BRANCH"
                 else
-                  echo "No c3_versions.json entry for $C3_KEY, falling back to master"
+                  echo "Neither '$CP_POST_BRANCH' nor '$CP_X_BRANCH' exists; falling back to master"
                   CP_ALL_IN_ONE_BRANCH=master
                 fi
-                export CP_ALL_IN_ONE_BRANCH
+              else
+                echo "No c3_versions.json entry for $C3_VERSION; falling back to master"
+                CP_ALL_IN_ONE_BRANCH=master
               fi
-              echo "Using cp-all-in-one branch: $CP_ALL_IN_ONE_BRANCH (C3_VERSION=$C3_VERSION)"
+              export CP_ALL_IN_ONE_BRANCH
+              echo "Using cp-all-in-one branch: $CP_ALL_IN_ONE_BRANCH (C3_VERSION=$C3_VERSION, CP_VERSION=$CP_VERSION)"
             - export ARCH_TAG="-ubi9$AMD_ARCH"
             - export DEV_C3_IMAGE="${DOCKER_DEV_REGISTRY}confluentinc/cp-enterprise-control-center-next-gen:${DOCKER_DEV_TAG}${ARCH_TAG}"
             - export DEV_PROM_IMAGE="${DOCKER_DEV_REGISTRY}confluentinc/cp-enterprise-prometheus:${DOCKER_DEV_TAG}${ARCH_TAG}"
@@ -203,7 +219,7 @@ blocks:
             - 'sed -i -E "s|image:[[:space:]]*confluentinc/cp-enterprise-prometheus:[^[:space:]]+|image: ${DEV_PROM_IMAGE}|g" docker-compose.yml'
             - 'sed -i -E "s|image:[[:space:]]*confluentinc/cp-enterprise-alertmanager:[^[:space:]]+|image: ${DEV_AM_IMAGE}|g" docker-compose.yml'
             - echo "Patched image refs:" && grep -E "^[[:space:]]*image:" docker-compose.yml
-            - docker compose pull control-center prometheus alertmanager
+            - docker compose pull
             - docker compose up -d
             - |
               echo "Waiting up to 10 minutes for control-center, prometheus, and alertmanager to become healthy..."

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -199,9 +199,9 @@ blocks:
             - rm -rf "$AIO_DIR"
             - git clone --depth 1 -b "$CP_ALL_IN_ONE_BRANCH" https://github.com/confluentinc/cp-all-in-one.git "$AIO_DIR"
             - cd "$AIO_DIR/cp-all-in-one"
-            - sed -i -E "s|image:[[:space:]]*confluentinc/cp-enterprise-control-center-next-gen:[^[:space:]]+|image: ${DEV_C3_IMAGE}|g" docker-compose.yml
-            - sed -i -E "s|image:[[:space:]]*confluentinc/cp-enterprise-prometheus:[^[:space:]]+|image: ${DEV_PROM_IMAGE}|g" docker-compose.yml
-            - sed -i -E "s|image:[[:space:]]*confluentinc/cp-enterprise-alertmanager:[^[:space:]]+|image: ${DEV_AM_IMAGE}|g" docker-compose.yml
+            - 'sed -i -E "s|image:[[:space:]]*confluentinc/cp-enterprise-control-center-next-gen:[^[:space:]]+|image: ${DEV_C3_IMAGE}|g" docker-compose.yml'
+            - 'sed -i -E "s|image:[[:space:]]*confluentinc/cp-enterprise-prometheus:[^[:space:]]+|image: ${DEV_PROM_IMAGE}|g" docker-compose.yml'
+            - 'sed -i -E "s|image:[[:space:]]*confluentinc/cp-enterprise-alertmanager:[^[:space:]]+|image: ${DEV_AM_IMAGE}|g" docker-compose.yml'
             - echo "Patched image refs:" && grep -E "^[[:space:]]*image:" docker-compose.yml
             - docker compose pull control-center prometheus alertmanager
             - docker compose up -d


### PR DESCRIPTION
## Summary

Automates the manual screenshot step from [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) so a broken docker image (cf. INC-6655 for C3 2.3.0) can't merge silently. Closes [MMA-17737](https://confluentinc.atlassian.net/browse/MMA-17737).

### What the new block does

`.semaphore/semaphore.yml` gets a new "Verify cp-all-in-one Docker Compose" block that runs on every PR after `Build, Test, & Scan AMD`. The actual logic lives in [.semaphore/scripts/verify-cp-all-in-one.sh](.semaphore/scripts/verify-cp-all-in-one.sh) (so it's easy to read, lint, and run locally outside CI), and the YAML block just invokes it with `up` and `down` subcommands. The script:

1. **Derives the matching cp-all-in-one branch** from this repo's `pom.xml` parent `<version>` (e.g. `[8.0.4-0, 8.0.5-0)` → `8.0.4`). The pom is the exact CP version the images are built against, so it's the authoritative source. Resolution order on cp-all-in-one:
   - Prefer `<cp-version>-post` (released-patch pin).
   - Else `<cp major.minor>.x` (active-dev branch — used when `-post` hasn't been cut yet but the CP line is in development).
   - Else `master` as last resort.
2. **Clones** the resolved branch of `confluentinc/cp-all-in-one`.
3. **Sed-patches** the three image refs (`cp-enterprise-control-center-next-gen`, `cp-enterprise-prometheus`, `cp-enterprise-alertmanager`) in `docker-compose.yml` to point at the PR's dev ECR tags. All other images (cp-server, schema-registry, ksqldb, etc.) are left untouched and pull from Docker Hub at their pinned CP version.
4. **`docker compose pull` then `docker compose up -d`** the whole stack; polls `:9021/`, `:9090/-/ready`, `:9093/-/ready` for HTTP 200 — up to 10 minutes (60 × 10s) — and fails the PR if any service doesn't come up.
5. **Tears down** with `docker compose ps` + per-service logs + `down -v` in the always-epilogue.

This would have caught INC-6655 (broken template file → C3 fails to start → `:9021/` never returns 200).

### Stale comment cleanup

Also removes the "managed by ServiceBot" header comment from all three `.semaphore/*.yml` files. This repo opted out of ServiceBot pipeline management in [4249d1b](https://github.com/confluentinc/control-center-next-gen-images/commit/4249d1b66a07b876ec2b6529a6666712f648958b) (Apr 2025) via `pipeline_enable: false` in `service.yml`, so the comment has been misleading for over a year. @krishvora01 (CPBR) confirmed in Slack the comment can go.

## Test plan

- [x] CI on this PR passes the new block end-to-end. Job log confirms:
  - `Using cp-all-in-one branch: 8.0.4-post (CP_VERSION=8.0.4, from pom.xml parent.version)` — pom-driven derivation hit, `*-post` branch selected.
  - `grep` after sed shows exactly the three enterprise images point at PR-built ECR URLs (`dev-2.3.x-<sha>-ubi9.amd64`); the other 10 services keep their `:8.0.4` public tags.
  - Healthchecks reach 200 in ~50s — well under the 10-minute cap.
  - Total verification block time: ~6 min.
  
## Rollout

Landing on 2.3.x first (lowest active branch). Will be forward-merged via pint-merge to 2.4.x → 2.5.x → 2.6.x → master. The script reads `pom.xml` at runtime, so the same code self-configures correctly on each branch — no per-branch fixups expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MMA-17737]: https://confluentinc.atlassian.net/browse/MMA-17737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ