### PR TITLE
MMA-18752: Migrate Docker images from ubi9-minimal to ubi9-micro base (2.6.x backport)

### DIFF
--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -13,10 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG UBI_MINIMAL_VERSION
+ARG APP_UID=1000
+ARG APP_GID=1000
+
+ARG UBI9_VERSION
 ARG UBI_MICRO_VERSION
 
-FROM registry.access.redhat.com/ubi9-minimal:${UBI_MINIMAL_VERSION} as builder
+FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} as builder
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
@@ -41,27 +44,32 @@ baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && microdnf install -y confluent-${COMPONENT}-${C3_VERSION} \
-    && microdnf install -y ca-certificates \
+    && dnf install -y --installroot=/microdir --releasever=9 confluent-${COMPONENT}-${C3_VERSION} \
+    && dnf install -y --installroot=/microdir --releasever=9 ca-certificates \
     && echo "===> Creating appuser..." \
     && useradd --no-log-init --create-home --shell /bin/bash appuser \
     && echo "===> Cleaning up ..."  \
-    && microdnf clean all \
+    && dnf --installroot=/microdir clean all \
     && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
     && echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p "${CONTROL_CENTER_DATA_DIR}" \
     && chown appuser:root -R "${CONTROL_CENTER_DATA_DIR}" \
-    && chown appuser:root -R "${CONTROL_CENTER_CONFIG_DIR}" \
-    && chmod -R ug+w "${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"
+    && chown appuser:root -R "/microdir${CONTROL_CENTER_CONFIG_DIR}" \
+    && chmod -R ug+w "/microdir${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"
 
 FROM registry.access.redhat.com/ubi9/ubi-micro:${UBI_MICRO_VERSION}
 WORKDIR /app
 USER root
 
+ARG APP_UID
+ARG APP_GID
 ARG ARCH
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 ARG GIT_COMMIT
+
+ENV APP_UID=${APP_UID}
+ENV APP_GID=${APP_GID}
 
 # Update package list and install essential packages
 
@@ -82,12 +90,12 @@ RUN mkdir -p /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager 
     mkdir -p /etc/confluent-control-center
 
 # Use the cleaned ARCH variable in subsequent commands
-COPY --from=builder /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/ /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/
-COPY --from=builder /etc/confluent-control-center/ /etc/confluent-control-center/
-COPY --from=builder /usr/bin/alertmanager-start /usr/bin/alertmanager-start
-COPY --from=builder /usr/bin/alertmanager-stop /usr/bin/alertmanager-stop
-COPY --from=builder /etc/pki/ca-trust /etc/pki/ca-trust
-COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+COPY --from=builder /microdir/usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/ /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/
+COPY --from=builder /microdir/etc/confluent-control-center/ /etc/confluent-control-center/
+COPY --from=builder /microdir/usr/bin/alertmanager-start /usr/bin/alertmanager-start
+COPY --from=builder /microdir/usr/bin/alertmanager-stop /usr/bin/alertmanager-stop
+COPY --from=builder /microdir/etc/pki/ca-trust /etc/pki/ca-trust
+COPY --from=builder /microdir/etc/ssl/certs /etc/ssl/certs
 
 EXPOSE 9093
 
@@ -98,9 +106,10 @@ RUN chmod +x /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/
 WORKDIR /usr/bin
 
 
-RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
+RUN echo "appuser:x:${APP_UID}:${APP_GID}::/home/appuser:/bin/sh" >> /etc/passwd && \
+    echo "appuser:x:${APP_GID}:" >> /etc/group && \
     mkdir -p /home/appuser && \
-    chown 1000:1000 /home/appuser
+    chown ${APP_UID}:${APP_GID} /home/appuser
 
 
 ## Creating the default log directory and data directory utilized by the script to ensure that Alertmanager
@@ -110,8 +119,8 @@ RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
 ## Security Practice: Adheres to the principle of least privilege.
 RUN mkdir -p /var/lib/confluent/control-center/alertmanager/ && \
     mkdir -p /var/log/confluent/control-center && \
-    chown -R 1000:1000 /etc/confluent-control-center /var/lib/confluent/control-center/alertmanager/ /var/log/confluent/control-center
-USER appuser
+    chown -R ${APP_UID}:${APP_GID} /etc/confluent-control-center /var/lib/confluent/control-center/alertmanager/ /var/log/confluent/control-center
+USER ${APP_UID}
 
 VOLUME     [ "/var/lib/confluent/control-center/alertmanager" ]
 ENTRYPOINT [ "alertmanager-start" ]

--- a/control-center/Dockerfile.ubi9
+++ b/control-center/Dockerfile.ubi9
@@ -13,27 +13,83 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ARG APP_UID=1000
+ARG APP_GID=1000
+
 ARG GOLANG_VERSION
-ARG UBI_MINIMAL_VERSION
+ARG UBI9_VERSION
+ARG UBI_MICRO_VERSION
+
+# Stage 1: Build ub utility binary
 FROM docker.io/golang:${GOLANG_VERSION} AS build-utilities
 
 ARG CP_DOCKER_UTILS_VERSION
 
 ENV GO_BIN="/go/bin"
 RUN CGO_ENABLED=0 go install -ldflags="-w -s" github.com/confluentinc/cp-docker-utils/cmd/ub@${CP_DOCKER_UTILS_VERSION}
-RUN CGO_ENABLED=0 go install -ldflags="-w -s" github.com/confluentinc/cp-docker-utils/cmd/package_dedupe@${CP_DOCKER_UTILS_VERSION}
 
 
-FROM registry.access.redhat.com/ubi9-minimal:${UBI_MINIMAL_VERSION}
+# Stage 2: Install packages to /microdir using full ubi9 with dnf
+FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} AS builder
 
+ARG APP_UID
+ARG APP_GID
+ARG TEMURIN_JDK_VERSION
+ARG C3_VERSION
+ARG CONFLUENT_PACKAGES_REPO
+
+RUN printf "[temurin-jre] \n\
+name=temurin-jre \n\
+baseurl=https://adoptium.jfrog.io/artifactory/rpm/rhel/\$releasever/\$basearch \n\
+enabled=1 \n\
+gpgcheck=1 \n\
+gpgkey=https://adoptium.jfrog.io/artifactory/api/gpg/key/public \n\
+" > /etc/yum.repos.d/adoptium.repo \
+    && rpm --import "${CONFLUENT_PACKAGES_REPO}/archive.key" \
+    && printf "[Confluent] \n\
+name=Confluent repository \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 " > /etc/yum.repos.d/confluent.repo \
+    && mkdir -p /microdir
+
+RUN echo "===> Installing Temurin JRE and Control Center Next Gen..." \
+    && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs \
+       "temurin-25-jre${TEMURIN_JDK_VERSION}" \
+       "confluent-control-center-next-gen-${C3_VERSION}" \
+       shadow-utils \
+    && echo "===> Removing unused services (Prometheus, Alertmanager)..." \
+    && rm -f /microdir/lib/systemd/system/prometheus.service \
+    && rm -rf /microdir/usr/libexec/confluent-control-center/linux_*/prometheus \
+    && rm -f /microdir/lib/systemd/system/alertmanager.service \
+    && rm -rf /microdir/usr/libexec/confluent-control-center/linux_*/alertmanager \
+    && echo "===> Cleaning up ..." \
+    && dnf --installroot=/microdir clean all \
+    && rm -rf /microdir/var/cache/* /microdir/var/log/dnf* /microdir/var/log/yum.* /microdir/tmp/* \
+    && rm /etc/yum.repos.d/adoptium.repo /etc/yum.repos.d/confluent.repo \
+    && rm -rf /microdir/lib/systemd \
+    && rm -rf /microdir/dev/* /microdir/proc/* /microdir/sys/*
+
+RUN echo "===> Creating appuser..." \
+    && chroot /microdir groupadd -g "${APP_GID}" appuser \
+    && chroot /microdir useradd -u "${APP_UID}" -g "${APP_GID}" --no-log-init --create-home --shell /bin/bash appuser
+
+
+# Stage 3: Final image using ubi9-micro
+FROM registry.access.redhat.com/ubi9-micro:${UBI_MICRO_VERSION}
+
+ARG APP_UID
+ARG APP_GID
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 ARG GIT_COMMIT
 ARG BUILD_NUMBER=-1
-ARG TEMURIN_JDK_VERSION
 ARG C3_VERSION
-ARG CONFLUENT_PACKAGES_REPO
 ARG CONFLUENT_PLATFORM_LABEL
+
+ENV APP_UID=${APP_UID}
+ENV APP_GID=${APP_GID}
 
 LABEL maintainer="partner-support@confluent.io"
 LABEL vendor="Confluent"
@@ -57,66 +113,29 @@ EXPOSE 9021
 
 USER root
 
-# Install cp-base-java dependencies (Temurin JRE)
-RUN printf "[temurin-jre] \n\
-name=temurin-jre \n\
-baseurl=https://adoptium.jfrog.io/artifactory/rpm/rhel/\$releasever/\$basearch \n\
-enabled=1 \n\
-gpgcheck=1 \n\
-gpgkey=https://adoptium.jfrog.io/artifactory/api/gpg/key/public \n\
-" > /etc/yum.repos.d/adoptium.repo \
-    && echo "===> Installing Temurin JRE..." \
-    && microdnf install -y temurin-25-jre${TEMURIN_JDK_VERSION} \
-    && microdnf clean all \
-    && echo "===> Creating appuser and directories..." \
-    && useradd --no-log-init --create-home --shell /bin/bash appuser \
-    && mkdir -p /etc/confluent/docker /usr/logs \
-    && chown appuser:appuser -R /etc/confluent/ /usr/logs \
-    && mkdir /licenses \
-    && rm /etc/yum.repos.d/adoptium.repo
-
 COPY --from=build-utilities /go/bin/ub /usr/bin/ub
-COPY --from=build-utilities /go/bin/package_dedupe /usr/bin/package_dedupe
+COPY --from=builder /microdir/ /
 
-RUN echo "===> Installing ${COMPONENT}..." \
-    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
-    && printf "[Confluent] \n\
-name=Confluent repository \n\
-baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
-gpgcheck=1 \n\
-gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
-enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && microdnf install -y confluent-${COMPONENT}-${C3_VERSION} \
-    && echo "===> Deduping jars present in /usr/share/java ..." \
-    && package_dedupe /usr/share/java \
-    && echo "===> Cleaning up ..." \
-    && microdnf clean all \
-    && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
-    && echo "===> Setting up ${COMPONENT} dirs" \
+RUN mkdir -p /etc/confluent/docker /usr/logs /licenses \
+    && chown "${APP_UID}:${APP_GID}" -R /etc/confluent/ /usr/logs
+
+RUN echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p "${CONTROL_CENTER_DATA_DIR}" \
-    && chown appuser:root -R "${CONTROL_CENTER_DATA_DIR}" \
-    && chown appuser:root -R "${CONTROL_CENTER_CONFIG_DIR}" \
-    && chmod -R ug+w "${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"\
-    && echo "===> Removing unused services (Prometheus, Alertmanager)..." \
-    && rm /usr/lib/systemd/system/prometheus.service && \
-    rm -r /usr/libexec/confluent-control-center/linux_*/prometheus && \
-    rm /usr/lib/systemd/system/alertmanager.service && \
-    rm -r /usr/libexec/confluent-control-center/linux_*/alertmanager
+    && chown "${APP_UID}":root -R "${CONTROL_CENTER_DATA_DIR}" "${CONTROL_CENTER_CONFIG_DIR}" \
+    && chmod -R ug+w "${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"
 
-
-# Copy files from target package to cp-base-new directory for backward compatibility (some paths are hardcoded in CFK startups scripts)
-COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/cp-base-new/
-COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/cp-base-new/
+# Copy files from target package to cp-base-new directory for backward compatibility (some paths are hardcoded in CFK startup scripts)
+COPY --chown=${APP_UID}:${APP_GID} target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/cp-base-new/
+COPY --chown=${APP_UID}:${APP_GID} target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/cp-base-new/
 
 # /usr/share/java/cp-base-java is the default java classpath for ub
 # jars in cp-base-new and cp-base-java are identical, so create a symlink to avoid duplicating files
 RUN ln -s /usr/share/java/cp-base-new /usr/share/java/cp-base-java
 
-
-COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
+COPY --chown=${APP_UID}:${APP_GID} include/etc/confluent/docker /etc/confluent/docker
 COPY license.txt /licenses/
 
-USER appuser
+USER ${APP_UID}
 WORKDIR /home/appuser
 
 CMD ["/etc/confluent/docker/run"]

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,9 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                 <configuration>
                     <buildArgs>
+                        <APP_UID>${app.uid}</APP_UID>
+                        <APP_GID>${app.gid}</APP_GID>
+                        <UBI9_VERSION>${ubi9.image.version}</UBI9_VERSION>
                         <UBI_MINIMAL_VERSION>${ubi9-minimal.image.version}</UBI_MINIMAL_VERSION>
                         <UBI_MICRO_VERSION>${ubi9-micro.image.version}</UBI_MICRO_VERSION>
                         <ARCH>${arch.type}</ARCH>
@@ -97,6 +100,9 @@
                 <image>
                   <build>
                     <args>
+                      <APP_UID>${app.uid}</APP_UID>
+                      <APP_GID>${app.gid}</APP_GID>
+                      <UBI9_VERSION>${ubi9.image.version}</UBI9_VERSION>
                       <UBI_MINIMAL_VERSION>${ubi9-minimal.image.version}</UBI_MINIMAL_VERSION>
                       <UBI_MICRO_VERSION>${ubi9-micro.image.version}</UBI_MICRO_VERSION>
                       <ARCH>${arch.type}</ARCH>
@@ -151,7 +157,16 @@
         the automation tooling can correctly identify and update them.
         -->
 
+        <!-- Application User Configuration
+             User and group IDs for the non-root user (appuser) configured in Docker images.
+             These values ensure consistent UID/GID across all container images and multi-stage builds,
+             preventing permission issues when copying files between stages or mounting volumes.
+             Can be overridden at build time via: -Dapp.uid=<value> -Dapp.gid=<value> -->
+        <app.uid>1000</app.uid>
+        <app.gid>1000</app.gid>
+
         <!-- Base Image Versions -->
+        <ubi9.image.version>9.7-1771346757</ubi9.image.version>
         <ubi9-minimal.image.version>9.7-1778562320</ubi9-minimal.image.version>
         <ubi9-micro.image.version>9.7-1778461406</ubi9-micro.image.version>
 

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -13,10 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG UBI_MINIMAL_VERSION
+ARG APP_UID=1000
+ARG APP_GID=1000
+
+ARG UBI9_VERSION
 ARG UBI_MICRO_VERSION
 
-FROM registry.access.redhat.com/ubi9-minimal:${UBI_MINIMAL_VERSION} as builder
+FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} as builder
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
@@ -42,27 +45,32 @@ baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && microdnf install -y confluent-${COMPONENT}-${C3_VERSION} \
-    && microdnf install -y ca-certificates \
+    && dnf install -y --installroot=/microdir --releasever=9 confluent-${COMPONENT}-${C3_VERSION} \
+    && dnf install -y --installroot=/microdir --releasever=9 ca-certificates \
     && echo "===> Creating appuser..." \
     && useradd --no-log-init --create-home --shell /bin/bash appuser \
     && echo "===> Cleaning up ..."  \
-    && microdnf clean all \
+    && dnf --installroot=/microdir clean all \
     && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
     && echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p "${CONTROL_CENTER_DATA_DIR}" \
     && chown appuser:root -R "${CONTROL_CENTER_DATA_DIR}" \
-    && chown appuser:root -R "${CONTROL_CENTER_CONFIG_DIR}" \
-    && chmod -R ug+w "${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"
+    && chown appuser:root -R "/microdir${CONTROL_CENTER_CONFIG_DIR}" \
+    && chmod -R ug+w "/microdir${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"
 
 FROM registry.access.redhat.com/ubi9/ubi-micro:${UBI_MICRO_VERSION}
 WORKDIR /app
 USER root
 
+ARG APP_UID
+ARG APP_GID
 ARG ARCH
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 ARG GIT_COMMIT
+
+ENV APP_UID=${APP_UID}
+ENV APP_GID=${APP_GID}
 
 # Update package list and install essential packages
 
@@ -83,12 +91,12 @@ RUN mkdir -p /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus &&
     mkdir -p /etc/confluent-control-center
 
 
-COPY --from=builder /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/ /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/
-COPY --from=builder /etc/confluent-control-center/ /etc/confluent-control-center/
-COPY --from=builder /usr/bin/prometheus-start /usr/bin/prometheus-start
-COPY --from=builder /usr/bin/prometheus-stop /usr/bin/prometheus-stop
-COPY --from=builder /etc/pki/ca-trust /etc/pki/ca-trust
-COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+COPY --from=builder /microdir/usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/ /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/
+COPY --from=builder /microdir/etc/confluent-control-center/ /etc/confluent-control-center/
+COPY --from=builder /microdir/usr/bin/prometheus-start /usr/bin/prometheus-start
+COPY --from=builder /microdir/usr/bin/prometheus-stop /usr/bin/prometheus-stop
+COPY --from=builder /microdir/etc/pki/ca-trust /etc/pki/ca-trust
+COPY --from=builder /microdir/etc/ssl/certs /etc/ssl/certs
 
 EXPOSE 9090
 
@@ -99,9 +107,10 @@ RUN chmod +x /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/pr
 WORKDIR /usr/bin
 
 
-RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
+RUN echo "appuser:x:${APP_UID}:${APP_GID}::/home/appuser:/bin/sh" >> /etc/passwd && \
+    echo "appuser:x:${APP_GID}:" >> /etc/group && \
     mkdir -p /home/appuser && \
-    chown 1000:1000 /home/appuser
+    chown ${APP_UID}:${APP_GID} /home/appuser
 
 ENV EXE_PATH="/usr/libexec/confluent-control-center"
 
@@ -112,9 +121,9 @@ ENV EXE_PATH="/usr/libexec/confluent-control-center"
 ## Security Practice: Adheres to the principle of least privilege.
 RUN mkdir -p /var/lib/confluent/control-center/prometheus/data && \
     mkdir -p /var/log/confluent/control-center && \
-    chown -R 1000:1000 /etc/confluent-control-center /var/lib/confluent/control-center/prometheus/data /var/log/confluent/control-center
+    chown -R ${APP_UID}:${APP_GID} /etc/confluent-control-center /var/lib/confluent/control-center/prometheus/data /var/log/confluent/control-center
 
-USER appuser
+USER ${APP_UID}
 
 VOLUME     [ "/var/lib/confluent/control-center/prometheus/data" ]
 ENTRYPOINT ["prometheus-start"]


### PR DESCRIPTION
## Summary

Backport of #193 to the `2.6.x` release branch (CP 8.3.0). Same migration: all three Docker images move from `ubi9-minimal` final base → `ubi9-micro`, builder switches from `ubi9-minimal + microdnf` to `ubi9 + dnf --installroot=/microdir`. Standardises `APP_UID`/`APP_GID` parameterisation across all three images.

## What changed per Dockerfile

- **`control-center/Dockerfile.ubi9`** — full 3-stage build (Go builder → ubi9 builder with `dnf --installroot=/microdir` → ubi9-micro final). Single Confluent RPM, no `package_dedupe`. Removes prometheus + alertmanager binaries from the c3 image (they ship as separate images) before COPY.
- **`alertmanager/Dockerfile.ubi9`** — minimal-diff migration. Builder switched from `ubi9-minimal+microdnf` to `ubi9+dnf --installroot=/microdir`. Final stage keeps the existing selective `COPY --from=builder /usr/...` pattern, only with source paths prefixed `/microdir/`. Everything else (USER root, ENV vars, useradd appuser, mkdir/chown/chmod, /etc/passwd echo, etc.) preserved exactly as in `2.6.x`.
- **`prometheus/Dockerfile.ubi9`** — same minimal-diff treatment as alertmanager.

## Why APP_UID/APP_GID parameterisation

For c3, ubi9-micro has no `useradd`, so the user is created in the ubi9 builder via `chroot useradd -u ${APP_UID}` and copied across. Parameterising via build args matches the org-wide common-docker convention and allows restricted environments to override at build time with `-Dapp.uid=N -Dapp.gid=N`.

For alertmanager / prometheus the appuser is still created in the final stage via `echo "appuser:x:${APP_UID}:${APP_GID}..." >> /etc/passwd` (same shape as 2.6.x, only the literals are now parameterised) — applied for consistency with c3 and the org convention.

## Test plan

- [ ] CI build passes (AMD64 + ARM64)
- [ ] cp-enterprise-control-center-next-gen image starts, listens on 9021, runs as non-root `${APP_UID}`
- [ ] alertmanager image starts, listens on 9093, runs as non-root `${APP_UID}`
- [ ] prometheus image starts, listens on 9090, runs as non-root `${APP_UID}`
- [ ] RedHat certification pipeline passes for all three images
- [ ] CFK e2e suite validates (CFK-4617 / CP 8.3 support)
