### PR TITLE
MMA-18752: Migrate Docker images to ubi9-micro base

### DIFF
--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -19,7 +19,7 @@ ARG APP_GID=1000
 ARG UBI9_VERSION
 ARG UBI_MICRO_VERSION
 
-FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} as builder
+FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} AS builder
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
@@ -37,14 +37,14 @@ ARG CONFLUENT_PLATFORM_LABEL
 USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
-    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
+    && rpm --import "${CONFLUENT_PACKAGES_REPO}/archive.key" \
     && printf "[Confluent] \n\
 name=Confluent repository \n\
 baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && dnf install -y --installroot=/microdir --releasever=9 confluent-${COMPONENT}-${C3_VERSION} ca-certificates \
+    && dnf install -y --installroot=/microdir --releasever=9 "confluent-${COMPONENT}-${C3_VERSION}" ca-certificates \
     && echo "===> Creating appuser..." \
     && useradd --no-log-init --create-home --shell /bin/bash appuser \
     && echo "===> Cleaning up ..."  \
@@ -108,7 +108,7 @@ WORKDIR /usr/bin
 RUN echo "appuser:x:${APP_UID}:${APP_GID}::/home/appuser:/bin/sh" >> /etc/passwd && \
     echo "appuser:x:${APP_GID}:" >> /etc/group && \
     mkdir -p /home/appuser && \
-    chown ${APP_UID}:${APP_GID} /home/appuser
+    chown "${APP_UID}:${APP_GID}" /home/appuser
 
 
 ## Creating the default log directory and data directory utilized by the script to ensure that Alertmanager
@@ -118,7 +118,7 @@ RUN echo "appuser:x:${APP_UID}:${APP_GID}::/home/appuser:/bin/sh" >> /etc/passwd
 ## Security Practice: Adheres to the principle of least privilege.
 RUN mkdir -p /var/lib/confluent/control-center/alertmanager/ && \
     mkdir -p /var/log/confluent/control-center && \
-    chown -R ${APP_UID}:${APP_GID} /etc/confluent-control-center /var/lib/confluent/control-center/alertmanager/ /var/log/confluent/control-center
+    chown -R "${APP_UID}:${APP_GID}" /etc/confluent-control-center /var/lib/confluent/control-center/alertmanager/ /var/log/confluent/control-center
 USER ${APP_UID}
 
 VOLUME     [ "/var/lib/confluent/control-center/alertmanager" ]

--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -44,7 +44,7 @@ baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && dnf install -y --installroot=/microdir --releasever=9 "confluent-${COMPONENT}-${C3_VERSION}" ca-certificates \
+    && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs "confluent-${COMPONENT}-${C3_VERSION}" ca-certificates \
     && echo "===> Cleaning up ..."  \
     && dnf --installroot=/microdir clean all \
     && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \

--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -45,15 +45,13 @@ gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && dnf install -y --installroot=/microdir --releasever=9 "confluent-${COMPONENT}-${C3_VERSION}" ca-certificates \
-    && echo "===> Creating appuser..." \
-    && useradd --no-log-init --create-home --shell /bin/bash appuser \
     && echo "===> Cleaning up ..."  \
     && dnf --installroot=/microdir clean all \
     && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
     && echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p "${CONTROL_CENTER_DATA_DIR}" \
-    && chown appuser:root -R "${CONTROL_CENTER_DATA_DIR}" \
-    && chown appuser:root -R "/microdir${CONTROL_CENTER_CONFIG_DIR}" \
+    && chown "${APP_UID}:0" -R "${CONTROL_CENTER_DATA_DIR}" \
+    && chown "${APP_UID}:0" -R "/microdir${CONTROL_CENTER_CONFIG_DIR}" \
     && chmod -R ug+w "/microdir${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"
 
 FROM registry.access.redhat.com/ubi9/ubi-micro:${UBI_MICRO_VERSION}

--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -44,8 +44,7 @@ baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && dnf install -y --installroot=/microdir --releasever=9 confluent-${COMPONENT}-${C3_VERSION} \
-    && dnf install -y --installroot=/microdir --releasever=9 ca-certificates \
+    && dnf install -y --installroot=/microdir --releasever=9 confluent-${COMPONENT}-${C3_VERSION} ca-certificates \
     && echo "===> Creating appuser..." \
     && useradd --no-log-init --create-home --shell /bin/bash appuser \
     && echo "===> Cleaning up ..."  \

--- a/alertmanager/Dockerfile.ubi9
+++ b/alertmanager/Dockerfile.ubi9
@@ -13,10 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG UBI_MINIMAL_VERSION
+ARG APP_UID=1000
+ARG APP_GID=1000
+
+ARG UBI9_VERSION
 ARG UBI_MICRO_VERSION
 
-FROM registry.access.redhat.com/ubi9-minimal:${UBI_MINIMAL_VERSION} as builder
+FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} as builder
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
@@ -41,27 +44,32 @@ baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && microdnf install -y confluent-${COMPONENT}-${C3_VERSION} \
-    && microdnf install -y ca-certificates \
+    && dnf install -y --installroot=/microdir --releasever=9 confluent-${COMPONENT}-${C3_VERSION} \
+    && dnf install -y --installroot=/microdir --releasever=9 ca-certificates \
     && echo "===> Creating appuser..." \
     && useradd --no-log-init --create-home --shell /bin/bash appuser \
     && echo "===> Cleaning up ..."  \
-    && microdnf clean all \
+    && dnf --installroot=/microdir clean all \
     && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
     && echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p "${CONTROL_CENTER_DATA_DIR}" \
     && chown appuser:root -R "${CONTROL_CENTER_DATA_DIR}" \
-    && chown appuser:root -R "${CONTROL_CENTER_CONFIG_DIR}" \
-    && chmod -R ug+w "${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"
+    && chown appuser:root -R "/microdir${CONTROL_CENTER_CONFIG_DIR}" \
+    && chmod -R ug+w "/microdir${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"
 
 FROM registry.access.redhat.com/ubi9/ubi-micro:${UBI_MICRO_VERSION}
 WORKDIR /app
 USER root
 
+ARG APP_UID
+ARG APP_GID
 ARG ARCH
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 ARG GIT_COMMIT
+
+ENV APP_UID=${APP_UID}
+ENV APP_GID=${APP_GID}
 
 # Update package list and install essential packages
 
@@ -82,12 +90,12 @@ RUN mkdir -p /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager 
     mkdir -p /etc/confluent-control-center
 
 # Use the cleaned ARCH variable in subsequent commands
-COPY --from=builder /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/ /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/
-COPY --from=builder /etc/confluent-control-center/ /etc/confluent-control-center/
-COPY --from=builder /usr/bin/alertmanager-start /usr/bin/alertmanager-start
-COPY --from=builder /usr/bin/alertmanager-stop /usr/bin/alertmanager-stop
-COPY --from=builder /etc/pki/ca-trust /etc/pki/ca-trust
-COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+COPY --from=builder /microdir/usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/ /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/
+COPY --from=builder /microdir/etc/confluent-control-center/ /etc/confluent-control-center/
+COPY --from=builder /microdir/usr/bin/alertmanager-start /usr/bin/alertmanager-start
+COPY --from=builder /microdir/usr/bin/alertmanager-stop /usr/bin/alertmanager-stop
+COPY --from=builder /microdir/etc/pki/ca-trust /etc/pki/ca-trust
+COPY --from=builder /microdir/etc/ssl/certs /etc/ssl/certs
 
 EXPOSE 9093
 
@@ -98,9 +106,10 @@ RUN chmod +x /usr/libexec/confluent-control-center/linux_${ARCH#.}/alertmanager/
 WORKDIR /usr/bin
 
 
-RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
+RUN echo "appuser:x:${APP_UID}:${APP_GID}::/home/appuser:/bin/sh" >> /etc/passwd && \
+    echo "appuser:x:${APP_GID}:" >> /etc/group && \
     mkdir -p /home/appuser && \
-    chown 1000:1000 /home/appuser
+    chown ${APP_UID}:${APP_GID} /home/appuser
 
 
 ## Creating the default log directory and data directory utilized by the script to ensure that Alertmanager
@@ -110,8 +119,8 @@ RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
 ## Security Practice: Adheres to the principle of least privilege.
 RUN mkdir -p /var/lib/confluent/control-center/alertmanager/ && \
     mkdir -p /var/log/confluent/control-center && \
-    chown -R 1000:1000 /etc/confluent-control-center /var/lib/confluent/control-center/alertmanager/ /var/log/confluent/control-center
-USER appuser
+    chown -R ${APP_UID}:${APP_GID} /etc/confluent-control-center /var/lib/confluent/control-center/alertmanager/ /var/log/confluent/control-center
+USER ${APP_UID}
 
 VOLUME     [ "/var/lib/confluent/control-center/alertmanager" ]
 ENTRYPOINT [ "alertmanager-start" ]

--- a/control-center/Dockerfile.ubi9
+++ b/control-center/Dockerfile.ubi9
@@ -13,27 +13,83 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ARG APP_UID=1000
+ARG APP_GID=1000
+
 ARG GOLANG_VERSION
-ARG UBI_MINIMAL_VERSION
+ARG UBI9_VERSION
+ARG UBI_MICRO_VERSION
+
+# Stage 1: Build ub utility binary
 FROM docker.io/golang:${GOLANG_VERSION} AS build-utilities
 
 ARG CP_DOCKER_UTILS_VERSION
 
 ENV GO_BIN="/go/bin"
 RUN CGO_ENABLED=0 go install -ldflags="-w -s" github.com/confluentinc/cp-docker-utils/cmd/ub@${CP_DOCKER_UTILS_VERSION}
-RUN CGO_ENABLED=0 go install -ldflags="-w -s" github.com/confluentinc/cp-docker-utils/cmd/package_dedupe@${CP_DOCKER_UTILS_VERSION}
 
 
-FROM registry.access.redhat.com/ubi9-minimal:${UBI_MINIMAL_VERSION}
+# Stage 2: Install packages to /microdir using full ubi9 with dnf
+FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} AS builder
 
+ARG APP_UID
+ARG APP_GID
+ARG TEMURIN_JDK_VERSION
+ARG C3_VERSION
+ARG CONFLUENT_PACKAGES_REPO
+
+RUN printf "[temurin-jre] \n\
+name=temurin-jre \n\
+baseurl=https://adoptium.jfrog.io/artifactory/rpm/rhel/\$releasever/\$basearch \n\
+enabled=1 \n\
+gpgcheck=1 \n\
+gpgkey=https://adoptium.jfrog.io/artifactory/api/gpg/key/public \n\
+" > /etc/yum.repos.d/adoptium.repo \
+    && rpm --import "${CONFLUENT_PACKAGES_REPO}/archive.key" \
+    && printf "[Confluent] \n\
+name=Confluent repository \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 " > /etc/yum.repos.d/confluent.repo \
+    && mkdir -p /microdir
+
+RUN echo "===> Installing Temurin JRE and Control Center Next Gen..." \
+    && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs \
+       "temurin-25-jre${TEMURIN_JDK_VERSION}" \
+       "confluent-control-center-next-gen-${C3_VERSION}" \
+       shadow-utils \
+    && echo "===> Removing unused services (Prometheus, Alertmanager)..." \
+    && rm -f /microdir/lib/systemd/system/prometheus.service \
+    && rm -rf /microdir/usr/libexec/confluent-control-center/linux_*/prometheus \
+    && rm -f /microdir/lib/systemd/system/alertmanager.service \
+    && rm -rf /microdir/usr/libexec/confluent-control-center/linux_*/alertmanager \
+    && echo "===> Cleaning up ..." \
+    && dnf --installroot=/microdir clean all \
+    && rm -rf /microdir/var/cache/* /microdir/var/log/dnf* /microdir/var/log/yum.* /microdir/tmp/* \
+    && rm /etc/yum.repos.d/adoptium.repo /etc/yum.repos.d/confluent.repo \
+    && rm -rf /microdir/lib/systemd \
+    && rm -rf /microdir/dev/* /microdir/proc/* /microdir/sys/*
+
+RUN echo "===> Creating appuser..." \
+    && chroot /microdir groupadd -g "${APP_GID}" appuser \
+    && chroot /microdir useradd -u "${APP_UID}" -g "${APP_GID}" --no-log-init --create-home --shell /bin/bash appuser
+
+
+# Stage 3: Final image using ubi9-micro
+FROM registry.access.redhat.com/ubi9-micro:${UBI_MICRO_VERSION}
+
+ARG APP_UID
+ARG APP_GID
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 ARG GIT_COMMIT
 ARG BUILD_NUMBER=-1
-ARG TEMURIN_JDK_VERSION
 ARG C3_VERSION
-ARG CONFLUENT_PACKAGES_REPO
 ARG CONFLUENT_PLATFORM_LABEL
+
+ENV APP_UID=${APP_UID}
+ENV APP_GID=${APP_GID}
 
 LABEL maintainer="partner-support@confluent.io"
 LABEL vendor="Confluent"
@@ -57,66 +113,29 @@ EXPOSE 9021
 
 USER root
 
-# Install cp-base-java dependencies (Temurin JRE)
-RUN printf "[temurin-jre] \n\
-name=temurin-jre \n\
-baseurl=https://adoptium.jfrog.io/artifactory/rpm/rhel/\$releasever/\$basearch \n\
-enabled=1 \n\
-gpgcheck=1 \n\
-gpgkey=https://adoptium.jfrog.io/artifactory/api/gpg/key/public \n\
-" > /etc/yum.repos.d/adoptium.repo \
-    && echo "===> Installing Temurin JRE..." \
-    && microdnf install -y temurin-25-jre${TEMURIN_JDK_VERSION} \
-    && microdnf clean all \
-    && echo "===> Creating appuser and directories..." \
-    && useradd --no-log-init --create-home --shell /bin/bash appuser \
-    && mkdir -p /etc/confluent/docker /usr/logs \
-    && chown appuser:appuser -R /etc/confluent/ /usr/logs \
-    && mkdir /licenses \
-    && rm /etc/yum.repos.d/adoptium.repo
-
 COPY --from=build-utilities /go/bin/ub /usr/bin/ub
-COPY --from=build-utilities /go/bin/package_dedupe /usr/bin/package_dedupe
+COPY --from=builder /microdir/ /
 
-RUN echo "===> Installing ${COMPONENT}..." \
-    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
-    && printf "[Confluent] \n\
-name=Confluent repository \n\
-baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
-gpgcheck=1 \n\
-gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
-enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && microdnf install -y confluent-${COMPONENT}-${C3_VERSION} \
-    && echo "===> Deduping jars present in /usr/share/java ..." \
-    && package_dedupe /usr/share/java \
-    && echo "===> Cleaning up ..." \
-    && microdnf clean all \
-    && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
-    && echo "===> Setting up ${COMPONENT} dirs" \
+RUN mkdir -p /etc/confluent/docker /usr/logs /licenses \
+    && chown "${APP_UID}:${APP_GID}" -R /etc/confluent/ /usr/logs
+
+RUN echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p "${CONTROL_CENTER_DATA_DIR}" \
-    && chown appuser:root -R "${CONTROL_CENTER_DATA_DIR}" \
-    && chown appuser:root -R "${CONTROL_CENTER_CONFIG_DIR}" \
-    && chmod -R ug+w "${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"\
-    && echo "===> Removing unused services (Prometheus, Alertmanager)..." \
-    && rm /usr/lib/systemd/system/prometheus.service && \
-    rm -r /usr/libexec/confluent-control-center/linux_*/prometheus && \
-    rm /usr/lib/systemd/system/alertmanager.service && \
-    rm -r /usr/libexec/confluent-control-center/linux_*/alertmanager
+    && chown "${APP_UID}":root -R "${CONTROL_CENTER_DATA_DIR}" "${CONTROL_CENTER_CONFIG_DIR}" \
+    && chmod -R ug+w "${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"
 
-
-# Copy files from target package to cp-base-new directory for backward compatibility (some paths are hardcoded in CFK startups scripts)
-COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/cp-base-new/
-COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/cp-base-new/
+# Copy files from target package to cp-base-new directory for backward compatibility (some paths are hardcoded in CFK startup scripts)
+COPY --chown=${APP_UID}:${APP_GID} target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/cp-base-new/
+COPY --chown=${APP_UID}:${APP_GID} target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/cp-base-new/
 
 # /usr/share/java/cp-base-java is the default java classpath for ub
 # jars in cp-base-new and cp-base-java are identical, so create a symlink to avoid duplicating files
 RUN ln -s /usr/share/java/cp-base-new /usr/share/java/cp-base-java
 
-
-COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
+COPY --chown=${APP_UID}:${APP_GID} include/etc/confluent/docker /etc/confluent/docker
 COPY license.txt /licenses/
 
-USER appuser
+USER ${APP_UID}
 WORKDIR /home/appuser
 
 CMD ["/etc/confluent/docker/run"]

--- a/control-center/Dockerfile.ubi9
+++ b/control-center/Dockerfile.ubi9
@@ -27,6 +27,7 @@ ARG CP_DOCKER_UTILS_VERSION
 
 ENV GO_BIN="/go/bin"
 RUN CGO_ENABLED=0 go install -ldflags="-w -s" github.com/confluentinc/cp-docker-utils/cmd/ub@${CP_DOCKER_UTILS_VERSION}
+RUN CGO_ENABLED=0 go install -ldflags="-w -s" github.com/confluentinc/cp-docker-utils/cmd/package_dedupe@${CP_DOCKER_UTILS_VERSION}
 
 
 # Stage 2: Install packages to /microdir using full ubi9 with dnf
@@ -54,6 +55,8 @@ gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && mkdir -p /microdir
 
+COPY --from=build-utilities /go/bin/package_dedupe /usr/local/bin/package_dedupe
+
 RUN echo "===> Installing Temurin JRE and Control Center Next Gen..." \
     && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs \
        "temurin-25-jre${TEMURIN_JDK_VERSION}" \
@@ -64,6 +67,8 @@ RUN echo "===> Installing Temurin JRE and Control Center Next Gen..." \
     && rm -rf /microdir/usr/libexec/confluent-control-center/linux_*/prometheus \
     && rm -f /microdir/lib/systemd/system/alertmanager.service \
     && rm -rf /microdir/usr/libexec/confluent-control-center/linux_*/alertmanager \
+    && echo "===> Deduping jars in /microdir ..." \
+    && package_dedupe /microdir/usr/share/java \
     && echo "===> Cleaning up ..." \
     && dnf --installroot=/microdir clean all \
     && rm -rf /microdir/var/cache/* /microdir/var/log/dnf* /microdir/var/log/yum.* /microdir/tmp/* \

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,9 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                 <configuration>
                     <buildArgs>
+                        <APP_UID>${app.uid}</APP_UID>
+                        <APP_GID>${app.gid}</APP_GID>
+                        <UBI9_VERSION>${ubi9.image.version}</UBI9_VERSION>
                         <UBI_MINIMAL_VERSION>${ubi9-minimal.image.version}</UBI_MINIMAL_VERSION>
                         <UBI_MICRO_VERSION>${ubi9-micro.image.version}</UBI_MICRO_VERSION>
                         <ARCH>${arch.type}</ARCH>
@@ -97,6 +100,9 @@
                 <image>
                   <build>
                     <args>
+                      <APP_UID>${app.uid}</APP_UID>
+                      <APP_GID>${app.gid}</APP_GID>
+                      <UBI9_VERSION>${ubi9.image.version}</UBI9_VERSION>
                       <UBI_MINIMAL_VERSION>${ubi9-minimal.image.version}</UBI_MINIMAL_VERSION>
                       <UBI_MICRO_VERSION>${ubi9-micro.image.version}</UBI_MICRO_VERSION>
                       <ARCH>${arch.type}</ARCH>
@@ -151,7 +157,16 @@
         the automation tooling can correctly identify and update them.
         -->
 
+        <!-- Application User Configuration
+             User and group IDs for the non-root user (appuser) configured in Docker images.
+             These values ensure consistent UID/GID across all container images and multi-stage builds,
+             preventing permission issues when copying files between stages or mounting volumes.
+             Can be overridden at build time via: -Dapp.uid=<value> -Dapp.gid=<value> -->
+        <app.uid>1000</app.uid>
+        <app.gid>1000</app.gid>
+
         <!-- Base Image Versions -->
+        <ubi9.image.version>9.7-1771346757</ubi9.image.version>
         <ubi9-minimal.image.version>9.7-1778562320</ubi9-minimal.image.version>
         <ubi9-micro.image.version>9.7-1778461406</ubi9-micro.image.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -95,12 +95,11 @@
                                     <APP_UID>${app.uid}</APP_UID>
                                     <APP_GID>${app.gid}</APP_GID>
                                     <UBI9_VERSION>${ubi9.image.version}</UBI9_VERSION>
-                                    <UBI_MINIMAL_VERSION>${ubi9-minimal.image.version}</UBI_MINIMAL_VERSION>
                                     <UBI_MICRO_VERSION>${ubi9-micro.image.version}</UBI_MICRO_VERSION>
                                     <ARCH>${arch.type}</ARCH>
                                     <C3_VERSION>${C3_VERSION}</C3_VERSION>
                                     <GOLANG_VERSION>${golang.image.version}</GOLANG_VERSION>
-                                    <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-25-jdk.version}</TEMURIN_JDK_VERSION>
+                                    <TEMURIN_JDK_VERSION>-${ubi9.temurin-25-jdk.version}</TEMURIN_JDK_VERSION>
                                     <CP_DOCKER_UTILS_VERSION>${git-repo.cp-docker-utils.tag}</CP_DOCKER_UTILS_VERSION>
                                 </args>
                             </build>
@@ -159,11 +158,10 @@
 
         <!-- Base Image Versions -->
         <ubi9.image.version>9.7-1771346757</ubi9.image.version>
-        <ubi9-minimal.image.version>9.8-1779809423</ubi9-minimal.image.version>
         <ubi9-micro.image.version>9.8-1779858820</ubi9-micro.image.version>
 
         <!-- OS Package Versions -->
-        <ubi9-minimal.temurin-25-jdk.version>25.0.3.0.0.9-0</ubi9-minimal.temurin-25-jdk.version>
+        <ubi9.temurin-25-jdk.version>25.0.3.0.0.9-0</ubi9.temurin-25-jdk.version>
 
         <!-- GitHub Repository Tags -->
         <git-repo.cp-docker-utils.tag>v1.0.12</git-repo.cp-docker-utils.tag>

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -46,15 +46,13 @@ gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && dnf install -y --installroot=/microdir --releasever=9 "confluent-${COMPONENT}-${C3_VERSION}" ca-certificates \
-    && echo "===> Creating appuser..." \
-    && useradd --no-log-init --create-home --shell /bin/bash appuser \
     && echo "===> Cleaning up ..."  \
     && dnf --installroot=/microdir clean all \
     && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
     && echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p "${CONTROL_CENTER_DATA_DIR}" \
-    && chown appuser:root -R "${CONTROL_CENTER_DATA_DIR}" \
-    && chown appuser:root -R "/microdir${CONTROL_CENTER_CONFIG_DIR}" \
+    && chown "${APP_UID}:0" -R "${CONTROL_CENTER_DATA_DIR}" \
+    && chown "${APP_UID}:0" -R "/microdir${CONTROL_CENTER_CONFIG_DIR}" \
     && chmod -R ug+w "/microdir${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"
 
 FROM registry.access.redhat.com/ubi9/ubi-micro:${UBI_MICRO_VERSION}

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -45,7 +45,7 @@ baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && dnf install -y --installroot=/microdir --releasever=9 "confluent-${COMPONENT}-${C3_VERSION}" ca-certificates \
+    && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs "confluent-${COMPONENT}-${C3_VERSION}" ca-certificates \
     && echo "===> Cleaning up ..."  \
     && dnf --installroot=/microdir clean all \
     && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -45,8 +45,7 @@ baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && dnf install -y --installroot=/microdir --releasever=9 confluent-${COMPONENT}-${C3_VERSION} \
-    && dnf install -y --installroot=/microdir --releasever=9 ca-certificates \
+    && dnf install -y --installroot=/microdir --releasever=9 confluent-${COMPONENT}-${C3_VERSION} ca-certificates \
     && echo "===> Creating appuser..." \
     && useradd --no-log-init --create-home --shell /bin/bash appuser \
     && echo "===> Cleaning up ..."  \

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -13,10 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG UBI_MINIMAL_VERSION
+ARG APP_UID=1000
+ARG APP_GID=1000
+
+ARG UBI9_VERSION
 ARG UBI_MICRO_VERSION
 
-FROM registry.access.redhat.com/ubi9-minimal:${UBI_MINIMAL_VERSION} as builder
+FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} as builder
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
@@ -42,27 +45,32 @@ baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && microdnf install -y confluent-${COMPONENT}-${C3_VERSION} \
-    && microdnf install -y ca-certificates \
+    && dnf install -y --installroot=/microdir --releasever=9 confluent-${COMPONENT}-${C3_VERSION} \
+    && dnf install -y --installroot=/microdir --releasever=9 ca-certificates \
     && echo "===> Creating appuser..." \
     && useradd --no-log-init --create-home --shell /bin/bash appuser \
     && echo "===> Cleaning up ..."  \
-    && microdnf clean all \
+    && dnf --installroot=/microdir clean all \
     && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
     && echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p "${CONTROL_CENTER_DATA_DIR}" \
     && chown appuser:root -R "${CONTROL_CENTER_DATA_DIR}" \
-    && chown appuser:root -R "${CONTROL_CENTER_CONFIG_DIR}" \
-    && chmod -R ug+w "${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"
+    && chown appuser:root -R "/microdir${CONTROL_CENTER_CONFIG_DIR}" \
+    && chmod -R ug+w "/microdir${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"
 
 FROM registry.access.redhat.com/ubi9/ubi-micro:${UBI_MICRO_VERSION}
 WORKDIR /app
 USER root
 
+ARG APP_UID
+ARG APP_GID
 ARG ARCH
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 ARG GIT_COMMIT
+
+ENV APP_UID=${APP_UID}
+ENV APP_GID=${APP_GID}
 
 # Update package list and install essential packages
 
@@ -83,12 +91,12 @@ RUN mkdir -p /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus &&
     mkdir -p /etc/confluent-control-center
 
 
-COPY --from=builder /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/ /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/
-COPY --from=builder /etc/confluent-control-center/ /etc/confluent-control-center/
-COPY --from=builder /usr/bin/prometheus-start /usr/bin/prometheus-start
-COPY --from=builder /usr/bin/prometheus-stop /usr/bin/prometheus-stop
-COPY --from=builder /etc/pki/ca-trust /etc/pki/ca-trust
-COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+COPY --from=builder /microdir/usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/ /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/
+COPY --from=builder /microdir/etc/confluent-control-center/ /etc/confluent-control-center/
+COPY --from=builder /microdir/usr/bin/prometheus-start /usr/bin/prometheus-start
+COPY --from=builder /microdir/usr/bin/prometheus-stop /usr/bin/prometheus-stop
+COPY --from=builder /microdir/etc/pki/ca-trust /etc/pki/ca-trust
+COPY --from=builder /microdir/etc/ssl/certs /etc/ssl/certs
 
 EXPOSE 9090
 
@@ -99,9 +107,10 @@ RUN chmod +x /usr/libexec/confluent-control-center/linux_${ARCH#.}/prometheus/pr
 WORKDIR /usr/bin
 
 
-RUN echo "appuser:x:1000:1000::/home/appuser:/bin/sh" >> /etc/passwd && \
+RUN echo "appuser:x:${APP_UID}:${APP_GID}::/home/appuser:/bin/sh" >> /etc/passwd && \
+    echo "appuser:x:${APP_GID}:" >> /etc/group && \
     mkdir -p /home/appuser && \
-    chown 1000:1000 /home/appuser
+    chown ${APP_UID}:${APP_GID} /home/appuser
 
 ENV EXE_PATH="/usr/libexec/confluent-control-center"
 
@@ -112,9 +121,9 @@ ENV EXE_PATH="/usr/libexec/confluent-control-center"
 ## Security Practice: Adheres to the principle of least privilege.
 RUN mkdir -p /var/lib/confluent/control-center/prometheus/data && \
     mkdir -p /var/log/confluent/control-center && \
-    chown -R 1000:1000 /etc/confluent-control-center /var/lib/confluent/control-center/prometheus/data /var/log/confluent/control-center
+    chown -R ${APP_UID}:${APP_GID} /etc/confluent-control-center /var/lib/confluent/control-center/prometheus/data /var/log/confluent/control-center
 
-USER appuser
+USER ${APP_UID}
 
 VOLUME     [ "/var/lib/confluent/control-center/prometheus/data" ]
 ENTRYPOINT ["prometheus-start"]

--- a/prometheus/Dockerfile.ubi9
+++ b/prometheus/Dockerfile.ubi9
@@ -19,7 +19,7 @@ ARG APP_GID=1000
 ARG UBI9_VERSION
 ARG UBI_MICRO_VERSION
 
-FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} as builder
+FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} AS builder
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
@@ -38,14 +38,14 @@ ARG CONFLUENT_PLATFORM_LABEL
 USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
-    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
+    && rpm --import "${CONFLUENT_PACKAGES_REPO}/archive.key" \
     && printf "[Confluent] \n\
 name=Confluent repository \n\
 baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && dnf install -y --installroot=/microdir --releasever=9 confluent-${COMPONENT}-${C3_VERSION} ca-certificates \
+    && dnf install -y --installroot=/microdir --releasever=9 "confluent-${COMPONENT}-${C3_VERSION}" ca-certificates \
     && echo "===> Creating appuser..." \
     && useradd --no-log-init --create-home --shell /bin/bash appuser \
     && echo "===> Cleaning up ..."  \
@@ -109,7 +109,7 @@ WORKDIR /usr/bin
 RUN echo "appuser:x:${APP_UID}:${APP_GID}::/home/appuser:/bin/sh" >> /etc/passwd && \
     echo "appuser:x:${APP_GID}:" >> /etc/group && \
     mkdir -p /home/appuser && \
-    chown ${APP_UID}:${APP_GID} /home/appuser
+    chown "${APP_UID}:${APP_GID}" /home/appuser
 
 ENV EXE_PATH="/usr/libexec/confluent-control-center"
 
@@ -120,7 +120,7 @@ ENV EXE_PATH="/usr/libexec/confluent-control-center"
 ## Security Practice: Adheres to the principle of least privilege.
 RUN mkdir -p /var/lib/confluent/control-center/prometheus/data && \
     mkdir -p /var/log/confluent/control-center && \
-    chown -R ${APP_UID}:${APP_GID} /etc/confluent-control-center /var/lib/confluent/control-center/prometheus/data /var/log/confluent/control-center
+    chown -R "${APP_UID}:${APP_GID}" /etc/confluent-control-center /var/lib/confluent/control-center/prometheus/data /var/log/confluent/control-center
 
 USER ${APP_UID}
 


### PR DESCRIPTION
## Summary

PR changes for ubi9 micro migration for c3++ docker images


## Why APP_UID/APP_GID parameterisation

  For **c3**, the final stage is raw `ubi9-micro` (no `useradd` binary), and the whole `/microdir` is COPY'd from the builder to the final image. So appuser must exist inside `/microdir/etc/passwd` **before** the
  COPY — created in the ubi9 builder via `chroot useradd -u ${APP_UID} -g ${APP_GID}`. After COPY, the final image has `appuser` at the parameterised UID/GID, and `USER ${APP_UID}` runs as that user.

  For **alertmanager** and **prometheus**, the final stage uses **selective** COPY (only specific paths like `/usr/libexec/.../{alertmanager,prometheus}/`, `/etc/confluent-control-center/`,
  `/usr/bin/{alertmanager,prometheus}-{start,stop}`, `/etc/pki/ca-trust`, `/etc/ssl/certs`) — `/etc/passwd` from the builder is **never** copied. So no builder-side appuser is needed; the builder just uses numeric
  `chown ${APP_UID}:0` on the paths that get COPYed. The appuser is created entirely in the final stage via `echo "appuser:x:${APP_UID}:${APP_GID}..." >> /etc/passwd` (same shape as 2.6.x master, only the literals
  are now parameterised).

  Parameterising via build args matches the org-wide common-docker convention and allows restricted environments to override at build time with `-Dapp.uid=N -Dapp.gid=N`. `${APP_UID}` now flows end-to-end through
  builder + final stage for all three images.

## Local Redhat Certification
Ran redhat certification on latest commit images: 
`519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/dev/confluentinc/cp-enterprise-control-center-next-gen:dev-2.6.x-42036a19-ubi9.amd64`, 
`519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/dev/confluentinc/cp-enterprise-prometheus:dev-2.6.x-42036a19-ubi9.amd64`,
`519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/dev/confluentinc/cp-enterprise-alertmanager:dev-2.6.x-42036a19-ubi9.amd64`

Certification workflow passes: https://semaphore.ci.confluent.io/workflows/42036a19-1bfb-41fc-81f6-7ff1ba0450fa?pipeline_id=207906c6-cc06-4fa8-9e93-7f75b6b0b625

## Test plan

- [x] **CI build passes** (AMD64 + ARM64) — Semaphore green ✅
- [x] **SonarQube quality gate** ✅
- [x] **cp-enterprise-control-center-next-gen image starts, listens on 9021, runs as non-root `${APP_UID}`** — validated via local cp-all-in-one ✅
- [x] **alertmanager image starts, listens on 9093, runs as non-root `${APP_UID}`** — ✅
- [x] **prometheus image starts, listens on 9090, runs as non-root `${APP_UID}`** — ✅
- [x] RedHat certification pipeline passes for all three images - https://semaphore.ci.confluent.io/workflows/a5a5638f-54d2-4f91-8750-568e54993731

## Local validation (cp-all-in-one)

Validated the freshly-built dev images (the arm64 build from the passing CI run on this PR) against the [`cp-all-in-one/8.2.0-post`](https://github.com/confluentinc/cp-all-in-one/blob/8.2.0-post/cp-all-in-one/docker-compose.yml) stack on darwin/arm64.

Steps:
- Pulled the three CI-built dev images from ECR
- Retagged as `confluentinc/cp-enterprise-{control-center-next-gen,prometheus,alertmanager}:2.5.0` to match the compose
- `docker compose up -d` in `cp-all-in-one/cp-all-in-one/`

Results:
- All three migrated containers (c3, prometheus, alertmanager) came Up alongside the rest of the cp-all-in-one stack (broker / connect / schema-registry / ksqldb / rest-proxy / flink)
- All three stable past 20+ minutes uptime, no restarts
- `GET http://localhost:9021/` → **HTTP 200**, 7852 bytes (the C3 UI shell)
- c3 logs healthy: JVM up, Kafka Streams threads polling, `alerts_producer ProducerId set to 17 with epoch 0` against broker, inbound `GET / HTTP/1.1" 200 7852` access-log entries
- `docker exec` confirms all three run as `uid=1000(appuser) gid=1000(appuser)` — non-root
- Image sizes (arm64): c3-next-gen 1.29 GB, prometheus 435 MB, alertmanager 104 MB

<img width="1695" height="923" alt="image" src="https://github.com/user-attachments/assets/92b619be-cf17-45a0-b4c0-e4645a6ced39" />
<img width="1695" height="246" alt="image" src="https://github.com/user-attachments/assets/13ef28ab-b295-4bfc-97f6-c17dd2eea816" />
<img width="1695" height="154" alt="image" src="https://github.com/user-attachments/assets/87c4e962-1821-417a-9a15-d4c5b2ef13be" />

