### PR TITLE
[CI validation only] MMA-17737 verify fix on master

### DIFF
--- a/.semaphore/scripts/verify-cp-all-in-one.sh
+++ b/.semaphore/scripts/verify-cp-all-in-one.sh
@@ -6,12 +6,16 @@
 # Addresses MMA-17737 / INC-6655 by automating the manual screenshot step in
 # .github/PULL_REQUEST_TEMPLATE.md.
 #
-# Real failures exit 1 — the pipeline shows FAILED so developers see it. The
-# Semaphore block is structured to depend on the last publish block, so by the
-# time we run there is nothing in-flight for fail_fast to cancel.
+# Exit code contract (the semaphore.yml wrapper translates these):
+#   0   verification ran and passed
+#   1   verification ran and failed (real regression — pipeline shows FAILED)
+#   88  "nothing to verify yet" — no matching cp-all-in-one branch, or
+#       platform images not in internal ECR. The wrapper turns this into
+#       SEMAPHORE_JOB_RESULT=stopped + return 130 so the Semaphore UI shows
+#       the block as Stopped (not Passed — avoids false-positive green).
 #
-# A genuinely "nothing to verify yet" state (no matching cp-all-in-one branch,
-# or platform images not yet in internal ECR) exits 0 with a loud SKIP banner.
+# The Semaphore block is structured to depend on the last publish block, so
+# by the time we run there is nothing in-flight for fail_fast to cancel.
 #
 # Usage:
 #   verify-cp-all-in-one.sh up    # clone, sed-patch, compose up, poll healthchecks
@@ -133,7 +137,10 @@ cmd_up() {
   branch=$(resolve_branch "$cp_version")
   if [ -z "$branch" ]; then
     skip_banner "no -post or ${cp_line}.x cp-all-in-one branch exists for CP $cp_version yet (likely too early in the CP release cycle)"
-    return 0
+    # Sentinel exit code 88 signals "skip" to the wrapper in semaphore.yml,
+    # which translates it into SEMAPHORE_JOB_RESULT=stopped so the block
+    # shows as Stopped (not Passed) in the UI — no false-positive green.
+    exit 88
   fi
 
   # For .x dev branches, cp-all-in-one's compose pins CP platform services to
@@ -147,7 +154,7 @@ cmd_up() {
       # use `if !` to catch a non-zero exit from ecr_has_cp_line_images.
       if ! missing_imgs=$(ecr_has_cp_line_images "$cp_line"); then
         skip_banner "cp-all-in-one '${branch}' exists but these ${cp_line}.x-latest-ubi9 images aren't in ${DOCKER_PROD_REGISTRY} yet: ${missing_imgs}"
-        return 0
+        exit 88
       fi
       ;;
   esac

--- a/.semaphore/scripts/verify-cp-all-in-one.sh
+++ b/.semaphore/scripts/verify-cp-all-in-one.sh
@@ -1,32 +1,11 @@
 #!/usr/bin/env bash
 #
-# Smoke-test the PR-built docker images by booting cp-all-in-one with them and
+# Smoke-test PR-built docker images by booting cp-all-in-one with them and
 # polling control-center, prometheus, and alertmanager for HTTP 200.
 #
-# Addresses MMA-17737 / INC-6655 by automating the manual screenshot step in
-# .github/PULL_REQUEST_TEMPLATE.md.
+# Usage: verify-cp-all-in-one.sh up | down
 #
-# Exit code contract (the semaphore.yml wrapper translates these):
-#   0   verification ran and passed
-#   1   verification ran and failed (real regression — pipeline shows FAILED)
-#   88  "nothing to verify yet" — no matching cp-all-in-one branch, or
-#       platform images not in internal ECR. The wrapper turns this into
-#       SEMAPHORE_JOB_RESULT=stopped + return 130 so the Semaphore UI shows
-#       the block as Stopped (not Passed — avoids false-positive green).
-#
-# The Semaphore block is structured to depend on the last publish block, so
-# by the time we run there is nothing in-flight for fail_fast to cancel.
-#
-# Usage:
-#   verify-cp-all-in-one.sh up    # clone, sed-patch, compose up, poll healthchecks
-#   verify-cp-all-in-one.sh down  # tear down (run in always-epilogue) — dumps
-#                                 # ps + per-service logs, then `compose down -v`.
-#
-# Required env vars (exported by the global Semaphore prologue):
-#   DOCKER_DEV_REGISTRY   e.g. 519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/dev/
-#   DOCKER_PROD_REGISTRY  e.g. 519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/prod/
-#   DOCKER_DEV_TAG        e.g. dev-2.3.x-327c2d06
-#   AMD_ARCH              e.g. .amd64
+# Required env: DOCKER_DEV_REGISTRY, DOCKER_DEV_TAG, AMD_ARCH
 
 set -euo pipefail
 
@@ -36,8 +15,6 @@ CP_ALL_IN_ONE_REPO=https://github.com/confluentinc/cp-all-in-one.git
 HEALTH_TIMEOUT_TRIES=60
 HEALTH_TIMEOUT_SLEEP=10
 
-# Derive the CP version from this repo's pom.xml parent <version>.
-# Example: "[8.0.4-0, 8.0.5-0)"  ->  "8.0.4"
 derive_cp_version() {
   local pom="$1"
   local parent_version
@@ -47,61 +24,30 @@ derive_cp_version() {
   echo "$parent_version" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1
 }
 
-# Resolve a cp-all-in-one branch for a given CP version.
-# Preference: "<cp>-post" (released-patch pin) > "<cp major.minor>.x" (active-dev).
-# Returns the branch name on stdout, or empty string if neither branch exists
-# (caller treats empty as a soft-skip — too early in the CP release cycle).
+# Resolve to the highest <X.Y.Z>-post branch <= the target CP version. The
+# released -post branches pin real published images; cp-all-in-one's master
+# and .x branches reference unpublished <line>.x-latest tags and don't work,
+# so we always fall back to the closest released line. Echoes empty if none.
 resolve_branch() {
-  local cp_version="$1"
-  local cp_post="${cp_version}-post"
-  local cp_x
-  cp_x="$(echo "$cp_version" | grep -oE '^[0-9]+\.[0-9]+').x"
-
-  if git ls-remote --exit-code --heads "$CP_ALL_IN_ONE_REPO" "$cp_post" >/dev/null 2>&1; then
-    echo "$cp_post"
-  elif git ls-remote --exit-code --heads "$CP_ALL_IN_ONE_REPO" "$cp_x" >/dev/null 2>&1; then
-    echo "$cp_x"
-  fi
-  # else: silent, empty stdout, caller soft-skips
-}
-
-# Check whether the internal ECR prod registry has the <line>.x-latest-ubi9
-# multi-arch manifests for all four CP platform images we will sed-patch.
-# Returns 0 if every probe succeeds. On failure, echoes a space-separated list
-# of missing image names to stdout and returns 1.
-ecr_has_cp_line_images() {
-  local cp_line="$1"  # e.g. "8.3"
-  local tag="${cp_line}.x-latest-ubi9"
-  local missing=()
-  local img url
-  for img in cp-server cp-kafka-rest cp-ksqldb-server cp-schema-registry; do
-    url="${DOCKER_PROD_REGISTRY}confluentinc/${img}:${tag}"
-    if ! docker manifest inspect "$url" >/dev/null 2>&1; then
-      missing+=("$img")
+  local target="$1" best="" v
+  while read -r v; do
+    [ -z "$v" ] && continue
+    if [ "$(printf '%s\n%s\n' "$v" "$target" | sort -V | head -1)" = "$v" ]; then
+      best="$v"
     fi
-  done
-  if [ ${#missing[@]} -gt 0 ]; then
-    echo "${missing[*]}"
-    return 1
-  fi
+  done < <(git ls-remote --heads "$CP_ALL_IN_ONE_REPO" \
+    | sed -nE 's#.*refs/heads/([0-9]+\.[0-9]+\.[0-9]+)-post$#\1#p' | sort -V)
+  [ -n "$best" ] && echo "${best}-post"
 }
 
-# Patch an image ref in docker-compose.yml from the upstream public repo to a
-# substitute URL. Fails loudly (exit 1) if either:
-#   - the expected upstream image ref isn't present in the compose file
-#     (cp-all-in-one upstream may have renamed/removed the service)
-#   - the substitution doesn't land (the regex matched something we didn't
-#     expect, or sed silently no-op'd)
-# Without these asserts, a non-matching sed would silently leave the upstream
-# image in place and the smoke test would falsely pass against images this PR
-# didn't build.
+# Asserts catch silent zero-match seds — a no-op sed would leave the public
+# image in place and falsely pass the test.
 patch_image() {
-  local image_repo="$1"          # e.g. "confluentinc/cp-enterprise-prometheus"
-  local replacement_url="$2"     # full registry URL with tag
+  local image_repo="$1"
+  local replacement_url="$2"
 
   if ! grep -qE "^[[:space:]]*image:[[:space:]]*${image_repo}:" docker-compose.yml; then
     echo "ERROR: docker-compose.yml has no image ref for '${image_repo}'." >&2
-    echo "       cp-all-in-one upstream may have renamed or removed this service." >&2
     exit 1
   fi
   sed -i -E "s|image:[[:space:]]*${image_repo}:[^[:space:]]+|image: ${replacement_url}|g" docker-compose.yml
@@ -111,55 +57,21 @@ patch_image() {
   fi
 }
 
-# Print a loud SKIP banner. Used when there's nothing meaningful to verify yet
-# (no matching cp-all-in-one branch, or no published CP platform images for
-# this CP line).
-skip_banner() {
-  local reason="$1"
-  echo ""
-  echo "================================================================================"
-  echo "SKIP: cp-all-in-one verification cannot run yet"
-  echo "  reason: $reason"
-  echo "  this is non-blocking: image publish/promote continues normally"
-  echo "================================================================================"
-}
-
 cmd_up() {
   local repo_root="$PWD"
-  local cp_version cp_line branch
+  local cp_version branch
   cp_version=$(derive_cp_version "$repo_root/pom.xml")
   if [ -z "$cp_version" ]; then
     echo "Could not derive CP version from $repo_root/pom.xml parent.version"
     exit 1
   fi
-  cp_line="$(echo "$cp_version" | grep -oE '^[0-9]+\.[0-9]+')"
 
   branch=$(resolve_branch "$cp_version")
   if [ -z "$branch" ]; then
-    skip_banner "no -post or ${cp_line}.x cp-all-in-one branch exists for CP $cp_version yet (likely too early in the CP release cycle)"
-    # Sentinel exit code 88 signals "skip" to the wrapper in semaphore.yml,
-    # which translates it into SEMAPHORE_JOB_RESULT=stopped so the block
-    # shows as Stopped (not Passed) in the UI — no false-positive green.
-    exit 88
+    echo "ERROR: no <X.Y.Z>-post branch <= CP $cp_version found on $CP_ALL_IN_ONE_REPO"
+    exit 1
   fi
-
-  # For .x dev branches, cp-all-in-one's compose pins CP platform services to
-  # <line>.x-latest tags which only exist in the internal Confluent ECR (not
-  # public Docker Hub). Probe all 4 platform images we will sed-patch; if any
-  # are missing, skip non-fatally with the specific missing names called out.
-  case "$branch" in
-    *.x)
-      local missing_imgs
-      # `set -e` doesn't propagate cmd-sub failure into a bare assignment, so
-      # use `if !` to catch a non-zero exit from ecr_has_cp_line_images.
-      if ! missing_imgs=$(ecr_has_cp_line_images "$cp_line"); then
-        skip_banner "cp-all-in-one '${branch}' exists but these ${cp_line}.x-latest-ubi9 images aren't in ${DOCKER_PROD_REGISTRY} yet: ${missing_imgs}"
-        exit 88
-      fi
-      ;;
-  esac
-
-  echo "Using cp-all-in-one branch: $branch (CP_VERSION=$cp_version, from pom.xml parent.version)"
+  echo "Using cp-all-in-one branch: $branch (target CP $cp_version, from pom.xml parent.version)"
 
   local arch_tag="-ubi9${AMD_ARCH}"
   local dev_c3="${DOCKER_DEV_REGISTRY}confluentinc/cp-enterprise-control-center-next-gen:${DOCKER_DEV_TAG}${arch_tag}"
@@ -174,23 +86,9 @@ cmd_up() {
   git clone --depth 1 -b "$branch" "$CP_ALL_IN_ONE_REPO" "$AIO_DIR"
   cd "$AIO_COMPOSE_DIR"
 
-  # Always: redirect the 3 enterprise images to the PR's dev ECR build.
   patch_image "confluentinc/cp-enterprise-control-center-next-gen" "$dev_c3"
   patch_image "confluentinc/cp-enterprise-prometheus"               "$dev_prom"
   patch_image "confluentinc/cp-enterprise-alertmanager"             "$dev_am"
-
-  # On .x dev branches only: cp-all-in-one's compose references CP platform
-  # tags that don't exist on Docker Hub (e.g. cp-server:8.3.x-latest). Redirect
-  # those to the equivalent <line>.x-latest-ubi9 multi-arch manifests in
-  # internal ECR, which the agent is already authed to.
-  if [[ "$branch" == *.x ]]; then
-    local prod_tag="${cp_line}.x-latest-ubi9"
-    echo "Dev branch detected — also redirecting CP platform images to internal ECR (${prod_tag})"
-    patch_image "confluentinc/cp-server"          "${DOCKER_PROD_REGISTRY}confluentinc/cp-server:${prod_tag}"
-    patch_image "confluentinc/cp-kafka-rest"      "${DOCKER_PROD_REGISTRY}confluentinc/cp-kafka-rest:${prod_tag}"
-    patch_image "confluentinc/cp-ksqldb-server"   "${DOCKER_PROD_REGISTRY}confluentinc/cp-ksqldb-server:${prod_tag}"
-    patch_image "confluentinc/cp-schema-registry" "${DOCKER_PROD_REGISTRY}confluentinc/cp-schema-registry:${prod_tag}"
-  fi
 
   echo "Patched image refs:"
   grep -E "^[[:space:]]*image:" docker-compose.yml

--- a/.semaphore/scripts/verify-cp-all-in-one.sh
+++ b/.semaphore/scripts/verify-cp-all-in-one.sh
@@ -71,7 +71,12 @@ cmd_up() {
     echo "ERROR: no <X.Y.Z>-post branch <= CP $cp_version found on $CP_ALL_IN_ONE_REPO"
     exit 1
   fi
-  echo "Using cp-all-in-one branch: $branch (target CP $cp_version, from pom.xml parent.version)"
+  if [ "$branch" = "${cp_version}-post" ]; then
+    echo "Using cp-all-in-one branch: $branch (exact match for CP $cp_version, from pom.xml parent.version)"
+  else
+    echo "WARNING: cp-all-in-one has no ${cp_version}-post branch for CP $cp_version (from pom.xml parent.version);"
+    echo "         falling back to closest released branch: $branch"
+  fi
 
   local arch_tag="-ubi9${AMD_ARCH}"
   local dev_c3="${DOCKER_DEV_REGISTRY}confluentinc/cp-enterprise-control-center-next-gen:${DOCKER_DEV_TAG}${arch_tag}"

--- a/.semaphore/scripts/verify-cp-all-in-one.sh
+++ b/.semaphore/scripts/verify-cp-all-in-one.sh
@@ -6,10 +6,12 @@
 # Addresses MMA-17737 / INC-6655 by automating the manual screenshot step in
 # .github/PULL_REQUEST_TEMPLATE.md.
 #
-# This script ALWAYS exits 0 from the top-level dispatcher so that a smoke-test
-# failure cannot trip Semaphore's fail_fast and cancel the parallel
-# Deploy/Manifest/Publish blocks. Failures are surfaced via loud banner output
-# in the job log instead.
+# Real failures exit 1 — the pipeline shows FAILED so developers see it. The
+# Semaphore block is structured to depend on the last publish block, so by the
+# time we run there is nothing in-flight for fail_fast to cancel.
+#
+# A genuinely "nothing to verify yet" state (no matching cp-all-in-one branch,
+# or platform images not yet in internal ECR) exits 0 with a loud SKIP banner.
 #
 # Usage:
 #   verify-cp-all-in-one.sh up    # clone, sed-patch, compose up, poll healthchecks
@@ -115,16 +117,6 @@ skip_banner() {
   echo "SKIP: cp-all-in-one verification cannot run yet"
   echo "  reason: $reason"
   echo "  this is non-blocking: image publish/promote continues normally"
-  echo "================================================================================"
-}
-
-# Print a loud FAILED banner. Used when verification ran but failed.
-failure_banner() {
-  echo ""
-  echo "================================================================================"
-  echo "cp-all-in-one VERIFICATION FAILED"
-  echo "  - this signal is non-blocking: image publish/promote continues normally"
-  echo "  - investigate logs above; do not merge if verification was the intent"
   echo "================================================================================"
 }
 
@@ -236,22 +228,8 @@ cmd_down() {
   docker compose down -v || true
 }
 
-# Top-level dispatcher.
-#
-# `up` runs cmd_up in a subshell so that any internal `exit 1` (from
-# patch_image asserts, healthcheck timeout, etc.) terminates only the subshell
-# and lets us print a loud FAILED banner and exit 0. This is intentional: a
-# verify failure must not cancel the parallel Deploy/Manifest/Publish blocks
-# via fail_fast.
 case "${1:-}" in
-  up)
-    if ( cmd_up ); then
-      :
-    else
-      failure_banner
-    fi
-    exit 0
-    ;;
+  up) cmd_up ;;
   down) cmd_down ;;
   *) echo "usage: $0 up|down" >&2; exit 2 ;;
 esac

--- a/.semaphore/scripts/verify-cp-all-in-one.sh
+++ b/.semaphore/scripts/verify-cp-all-in-one.sh
@@ -6,15 +6,21 @@
 # Addresses MMA-17737 / INC-6655 by automating the manual screenshot step in
 # .github/PULL_REQUEST_TEMPLATE.md.
 #
+# This script ALWAYS exits 0 from the top-level dispatcher so that a smoke-test
+# failure cannot trip Semaphore's fail_fast and cancel the parallel
+# Deploy/Manifest/Publish blocks. Failures are surfaced via loud banner output
+# in the job log instead.
+#
 # Usage:
 #   verify-cp-all-in-one.sh up    # clone, sed-patch, compose up, poll healthchecks
 #   verify-cp-all-in-one.sh down  # tear down (run in always-epilogue) — dumps
 #                                 # ps + per-service logs, then `compose down -v`.
 #
 # Required env vars (exported by the global Semaphore prologue):
-#   DOCKER_DEV_REGISTRY  e.g. 519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/dev/
-#   DOCKER_DEV_TAG       e.g. dev-2.3.x-327c2d06
-#   AMD_ARCH             e.g. .amd64
+#   DOCKER_DEV_REGISTRY   e.g. 519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/dev/
+#   DOCKER_PROD_REGISTRY  e.g. 519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/prod/
+#   DOCKER_DEV_TAG        e.g. dev-2.3.x-327c2d06
+#   AMD_ARCH              e.g. .amd64
 
 set -euo pipefail
 
@@ -37,9 +43,8 @@ derive_cp_version() {
 
 # Resolve a cp-all-in-one branch for a given CP version.
 # Preference: "<cp>-post" (released-patch pin) > "<cp major.minor>.x" (active-dev).
-# If neither exists, fails loudly (exit 1) rather than silently testing against
-# cp-all-in-one master — testing C3 images against a non-matching CP version
-# would give a misleading verification signal.
+# Returns the branch name on stdout, or empty string if neither branch exists
+# (caller treats empty as a soft-skip — too early in the CP release cycle).
 resolve_branch() {
   local cp_version="$1"
   local cp_post="${cp_version}-post"
@@ -50,26 +55,43 @@ resolve_branch() {
     echo "$cp_post"
   elif git ls-remote --exit-code --heads "$CP_ALL_IN_ONE_REPO" "$cp_x" >/dev/null 2>&1; then
     echo "$cp_x"
-  else
-    echo "ERROR: Neither '$cp_post' nor '$cp_x' exists on $CP_ALL_IN_ONE_REPO." >&2
-    echo "       Coordinate with cp-all-in-one maintainers to create a branch" >&2
-    echo "       matching CP $cp_version before this PR can be verified." >&2
+  fi
+  # else: silent, empty stdout, caller soft-skips
+}
+
+# Check whether the internal ECR prod registry has the <line>.x-latest-ubi9
+# multi-arch manifests for all four CP platform images we will sed-patch.
+# Returns 0 if every probe succeeds. On failure, echoes a space-separated list
+# of missing image names to stdout and returns 1.
+ecr_has_cp_line_images() {
+  local cp_line="$1"  # e.g. "8.3"
+  local tag="${cp_line}.x-latest-ubi9"
+  local missing=()
+  local img url
+  for img in cp-server cp-kafka-rest cp-ksqldb-server cp-schema-registry; do
+    url="${DOCKER_PROD_REGISTRY}confluentinc/${img}:${tag}"
+    if ! docker manifest inspect "$url" >/dev/null 2>&1; then
+      missing+=("$img")
+    fi
+  done
+  if [ ${#missing[@]} -gt 0 ]; then
+    echo "${missing[*]}"
     return 1
   fi
 }
 
-# Patch an image ref in docker-compose.yml from the upstream public repo to
-# the PR's dev ECR URL. Fails loudly (exit 1) if either:
+# Patch an image ref in docker-compose.yml from the upstream public repo to a
+# substitute URL. Fails loudly (exit 1) if either:
 #   - the expected upstream image ref isn't present in the compose file
 #     (cp-all-in-one upstream may have renamed/removed the service)
 #   - the substitution doesn't land (the regex matched something we didn't
 #     expect, or sed silently no-op'd)
-# Without these asserts, a non-matching sed would silently leave the
-# upstream image in place and the smoke test would falsely pass against
-# images this PR didn't build.
+# Without these asserts, a non-matching sed would silently leave the upstream
+# image in place and the smoke test would falsely pass against images this PR
+# didn't build.
 patch_image() {
   local image_repo="$1"          # e.g. "confluentinc/cp-enterprise-prometheus"
-  local replacement_url="$2"     # full dev ECR URL with tag
+  local replacement_url="$2"     # full registry URL with tag
 
   if ! grep -qE "^[[:space:]]*image:[[:space:]]*${image_repo}:" docker-compose.yml; then
     echo "ERROR: docker-compose.yml has no image ref for '${image_repo}'." >&2
@@ -83,20 +105,61 @@ patch_image() {
   fi
 }
 
+# Print a loud SKIP banner. Used when there's nothing meaningful to verify yet
+# (no matching cp-all-in-one branch, or no published CP platform images for
+# this CP line).
+skip_banner() {
+  local reason="$1"
+  echo ""
+  echo "================================================================================"
+  echo "SKIP: cp-all-in-one verification cannot run yet"
+  echo "  reason: $reason"
+  echo "  this is non-blocking: image publish/promote continues normally"
+  echo "================================================================================"
+}
+
+# Print a loud FAILED banner. Used when verification ran but failed.
+failure_banner() {
+  echo ""
+  echo "================================================================================"
+  echo "cp-all-in-one VERIFICATION FAILED"
+  echo "  - this signal is non-blocking: image publish/promote continues normally"
+  echo "  - investigate logs above; do not merge if verification was the intent"
+  echo "================================================================================"
+}
+
 cmd_up() {
   local repo_root="$PWD"
-  local cp_version branch
+  local cp_version cp_line branch
   cp_version=$(derive_cp_version "$repo_root/pom.xml")
   if [ -z "$cp_version" ]; then
     echo "Could not derive CP version from $repo_root/pom.xml parent.version"
     exit 1
   fi
+  cp_line="$(echo "$cp_version" | grep -oE '^[0-9]+\.[0-9]+')"
 
-  # `set -e` doesn't propagate command-substitution failure into a bare assignment,
-  # so we use `if !` to explicitly catch a non-zero exit from resolve_branch.
-  if ! branch=$(resolve_branch "$cp_version"); then
-    exit 1
+  branch=$(resolve_branch "$cp_version")
+  if [ -z "$branch" ]; then
+    skip_banner "no -post or ${cp_line}.x cp-all-in-one branch exists for CP $cp_version yet (likely too early in the CP release cycle)"
+    return 0
   fi
+
+  # For .x dev branches, cp-all-in-one's compose pins CP platform services to
+  # <line>.x-latest tags which only exist in the internal Confluent ECR (not
+  # public Docker Hub). Probe all 4 platform images we will sed-patch; if any
+  # are missing, skip non-fatally with the specific missing names called out.
+  case "$branch" in
+    *.x)
+      local missing_imgs
+      # `set -e` doesn't propagate cmd-sub failure into a bare assignment, so
+      # use `if !` to catch a non-zero exit from ecr_has_cp_line_images.
+      if ! missing_imgs=$(ecr_has_cp_line_images "$cp_line"); then
+        skip_banner "cp-all-in-one '${branch}' exists but these ${cp_line}.x-latest-ubi9 images aren't in ${DOCKER_PROD_REGISTRY} yet: ${missing_imgs}"
+        return 0
+      fi
+      ;;
+  esac
+
   echo "Using cp-all-in-one branch: $branch (CP_VERSION=$cp_version, from pom.xml parent.version)"
 
   local arch_tag="-ubi9${AMD_ARCH}"
@@ -112,9 +175,23 @@ cmd_up() {
   git clone --depth 1 -b "$branch" "$CP_ALL_IN_ONE_REPO" "$AIO_DIR"
   cd "$AIO_COMPOSE_DIR"
 
+  # Always: redirect the 3 enterprise images to the PR's dev ECR build.
   patch_image "confluentinc/cp-enterprise-control-center-next-gen" "$dev_c3"
   patch_image "confluentinc/cp-enterprise-prometheus"               "$dev_prom"
   patch_image "confluentinc/cp-enterprise-alertmanager"             "$dev_am"
+
+  # On .x dev branches only: cp-all-in-one's compose references CP platform
+  # tags that don't exist on Docker Hub (e.g. cp-server:8.3.x-latest). Redirect
+  # those to the equivalent <line>.x-latest-ubi9 multi-arch manifests in
+  # internal ECR, which the agent is already authed to.
+  if [[ "$branch" == *.x ]]; then
+    local prod_tag="${cp_line}.x-latest-ubi9"
+    echo "Dev branch detected — also redirecting CP platform images to internal ECR (${prod_tag})"
+    patch_image "confluentinc/cp-server"          "${DOCKER_PROD_REGISTRY}confluentinc/cp-server:${prod_tag}"
+    patch_image "confluentinc/cp-kafka-rest"      "${DOCKER_PROD_REGISTRY}confluentinc/cp-kafka-rest:${prod_tag}"
+    patch_image "confluentinc/cp-ksqldb-server"   "${DOCKER_PROD_REGISTRY}confluentinc/cp-ksqldb-server:${prod_tag}"
+    patch_image "confluentinc/cp-schema-registry" "${DOCKER_PROD_REGISTRY}confluentinc/cp-schema-registry:${prod_tag}"
+  fi
 
   echo "Patched image refs:"
   grep -E "^[[:space:]]*image:" docker-compose.yml
@@ -159,8 +236,22 @@ cmd_down() {
   docker compose down -v || true
 }
 
+# Top-level dispatcher.
+#
+# `up` runs cmd_up in a subshell so that any internal `exit 1` (from
+# patch_image asserts, healthcheck timeout, etc.) terminates only the subshell
+# and lets us print a loud FAILED banner and exit 0. This is intentional: a
+# verify failure must not cancel the parallel Deploy/Manifest/Publish blocks
+# via fail_fast.
 case "${1:-}" in
-  up) cmd_up ;;
+  up)
+    if ( cmd_up ); then
+      :
+    else
+      failure_banner
+    fi
+    exit 0
+    ;;
   down) cmd_down ;;
   *) echo "usage: $0 up|down" >&2; exit 2 ;;
 esac

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -197,7 +197,13 @@ blocks:
             # Translate that into SEMAPHORE_JOB_RESULT=stopped + return 130
             # so the block shows as Stopped (not Passed) in the UI — avoids
             # a false-positive green. Pattern from confluentinc/packaging.
-            # Other exit codes (0 = passed, 1 = failed) pass through normally.
+            # Other exit codes (0 = passed, 1 = failed) pass through via
+            # `return "$rc"`.
+            #
+            # IMPORTANT: use `return`, not `exit`. Semaphore sources these
+            # `- |` blocks into a shared shell session; `exit` terminates
+            # that session and Semaphore reports the step as exit 1
+            # regardless of what value was passed.
             #
             # `|| rc=$?` captures the script's non-zero exit without letting
             # the shell's set -e terminate the wrapper before we can dispatch.
@@ -208,7 +214,7 @@ blocks:
                 export SEMAPHORE_JOB_RESULT=stopped
                 return 130
               fi
-              exit "$rc"
+              return "$rc"
       epilogue:
         always:
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -192,7 +192,23 @@ blocks:
       jobs:
         - name: cp-all-in-one docker compose smoke test
           commands:
-            - .semaphore/scripts/verify-cp-all-in-one.sh up
+            # The script uses exit code 88 to signal "skip" — no matching
+            # cp-all-in-one branch, or platform images not in ECR yet.
+            # Translate that into SEMAPHORE_JOB_RESULT=stopped + return 130
+            # so the block shows as Stopped (not Passed) in the UI — avoids
+            # a false-positive green. Pattern from confluentinc/packaging.
+            # Other exit codes (0 = passed, 1 = failed) pass through normally.
+            #
+            # `|| rc=$?` captures the script's non-zero exit without letting
+            # the shell's set -e terminate the wrapper before we can dispatch.
+            - |
+              rc=0
+              .semaphore/scripts/verify-cp-all-in-one.sh up || rc=$?
+              if [ "$rc" -eq 88 ]; then
+                export SEMAPHORE_JOB_RESULT=stopped
+                return 130
+              fi
+              exit "$rc"
       epilogue:
         always:
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -173,17 +173,6 @@ blocks:
             - . publish-test-results
             - artifact push workflow target/test-results
             - artifact push workflow target --destination target-S390X
-  # Automates the manual verification described in .github/PULL_REQUEST_TEMPLATE.md:
-  # boots cp-all-in-one with the PR-built dev images and waits for control-center,
-  # prometheus, and alertmanager to respond healthy. Addresses MMA-17737 / INC-6655.
-  # Logic lives in .semaphore/scripts/verify-cp-all-in-one.sh so it's easy to
-  # debug, lint, and run locally outside of CI.
-  #
-  # Depends on the last block in the publish chain so that a verify failure
-  # cannot cause fail_fast to cancel any in-flight Deploy/Manifest/Publish
-  # block — they're all already done by the time verify runs. A real verify
-  # failure still surfaces as a failed pipeline (developer-visible) without
-  # blocking image publish/promote.
   - name: Verify cp-all-in-one Docker Compose
     dependencies: ["Push docker images tags summary to artifacts"]
     run:
@@ -192,29 +181,7 @@ blocks:
       jobs:
         - name: cp-all-in-one docker compose smoke test
           commands:
-            # The script uses exit code 88 to signal "skip" — no matching
-            # cp-all-in-one branch, or platform images not in ECR yet.
-            # Translate that into SEMAPHORE_JOB_RESULT=stopped + return 130
-            # so the block shows as Stopped (not Passed) in the UI — avoids
-            # a false-positive green. Pattern from confluentinc/packaging.
-            # Other exit codes (0 = passed, 1 = failed) pass through via
-            # `return "$rc"`.
-            #
-            # IMPORTANT: use `return`, not `exit`. Semaphore sources these
-            # `- |` blocks into a shared shell session; `exit` terminates
-            # that session and Semaphore reports the step as exit 1
-            # regardless of what value was passed.
-            #
-            # `|| rc=$?` captures the script's non-zero exit without letting
-            # the shell's set -e terminate the wrapper before we can dispatch.
-            - |
-              rc=0
-              .semaphore/scripts/verify-cp-all-in-one.sh up || rc=$?
-              if [ "$rc" -eq 88 ]; then
-                export SEMAPHORE_JOB_RESULT=stopped
-                return 130
-              fi
-              return "$rc"
+            - .semaphore/scripts/verify-cp-all-in-one.sh up
       epilogue:
         always:
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -178,8 +178,14 @@ blocks:
   # prometheus, and alertmanager to respond healthy. Addresses MMA-17737 / INC-6655.
   # Logic lives in .semaphore/scripts/verify-cp-all-in-one.sh so it's easy to
   # debug, lint, and run locally outside of CI.
+  #
+  # Depends on the last block in the publish chain so that a verify failure
+  # cannot cause fail_fast to cancel any in-flight Deploy/Manifest/Publish
+  # block — they're all already done by the time verify runs. A real verify
+  # failure still surfaces as a failed pipeline (developer-visible) without
+  # blocking image publish/promote.
   - name: Verify cp-all-in-one Docker Compose
-    dependencies: ["Build, Test, & Scan AMD"]
+    dependencies: ["Push docker images tags summary to artifacts"]
     run:
       when: "pull_request =~ '.*'"
     task:


### PR DESCRIPTION
Parallel fix for [MMA-17737](https://confluentinc.atlassian.net/browse/MMA-17737), targeting master so we can exercise the **soft-skip path** in CI.

Same commit as #303 (2.5.x) and #304 (2.6.x). Single-file change to `.semaphore/scripts/verify-cp-all-in-one.sh`.

## Why a parallel PR on master

Master is the third behavioral path of this fix: CP 8.4.0 has neither a `8.4.0-post` nor a `8.4.x` branch on cp-all-in-one yet, AND none of the 4 platform images exist at `8.4.x-latest-ubi9` in internal ECR (verified locally). This is the "too early in the CP release cycle" case.

Before this fix, this state would either hard-fail (canceling publish via fail_fast) or silently fall back to master (misleading signal). With this fix, it should print a loud SKIP banner and exit 0.

## Expected CI output on this PR

- Branch resolution: empty (no `8.4.0-post`, no `8.4.x`)
- SKIP banner:
  ```
  ================================================================================
  SKIP: cp-all-in-one verification cannot run yet
    reason: no -post or 8.4.x cp-all-in-one branch exists for CP 8.4.0 yet (likely too early in the CP release cycle)
    this is non-blocking: image publish/promote continues normally
  ================================================================================
  ```
- Job result: passed (exit 0)
- No `Dev branch detected`, no FAILED banner

## Merge strategy

CI-validation PR only. Once #303 merges to 2.5.x, pint will forward-merge the fix through 2.6.x → master, and this PR can be closed.

[MMA-17737]: https://confluentinc.atlassian.net/browse/MMA-17737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ