### PR TITLE
CPBR-3911: pull C3 packages from version-isolated <type>/<minor>/

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,8 +1,3 @@
-# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
-# template and configurations in service.yml.
-# Any modifications made to ths file will be overwritten by the generated content in nightly runs.
-# For more information, please refer to the page:
-# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
 version: v1.0
 name: build-test-release
 agent:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -35,8 +35,10 @@ global_job_config:
       - export PACKAGING_BUCKET="s3://dev-control-center-packages-654654529379-us-west-2/confluent-control-center-next-gen/$BRANCH_TAG/"
       # Check if version is complete, otherwise use the previous version
       - export C3_VERSION=2.7.0 #hardcoded for now
+      # packages are version-isolated under <type>/<minor>/ (e.g. rpm/2.7/), so derive the minor
+      - export C3_MAJOR_MINOR=$(echo "$C3_VERSION" | cut -d. -f1,2)
       - export DEFAULT_OS_TYPE="ubi"
-      - export PACKAGES_URL="https://s3-us-west-2.amazonaws.com/dev-control-center-packages-654654529379-us-west-2/confluent-control-center-next-gen/$BRANCH_TAG/latest/PACKAGE_TYPE"
+      - export PACKAGES_URL="https://s3-us-west-2.amazonaws.com/dev-control-center-packages-654654529379-us-west-2/confluent-control-center-next-gen/$BRANCH_TAG/latest/PACKAGE_TYPE/$C3_MAJOR_MINOR"
       - 'echo "PACKAGES_URL: ${PACKAGES_URL}"'
       - export PACKAGING_BUILD_NUMBER=$LATEST_PACKAGING_BUILD_NUMBER
       - >-

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,3 +1,8 @@
+# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
+# template and configurations in service.yml.
+# Any modifications made to ths file will be overwritten by the generated content in nightly runs.
+# For more information, please refer to the page:
+# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
 version: v1.0
 name: build-test-release
 agent:


### PR DESCRIPTION
C3 packaging now publishes under `<type>/<minor>/`, so the image build has to pull from the minor dir. Derives the minor from `C3_VERSION` and appends it to `PACKAGES_URL` in `semaphore.yml`, so the existing `sed PACKAGE_TYPE→rpm` resolves to `.../latest/rpm/2.7`.

The release-flow build (`cp_dockerfile_build.yml`) already receives the versioned URL from the packaging trigger, and the Dockerfile just consumes `CONFLUENT_PACKAGES_REPO`, so neither needs changing. C3 only.