### PR TITLE
Remove stale ServiceBot-managed header from .semaphore configs

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -1,8 +1,3 @@
-# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
-# template and configurations in service.yml.
-# Any modifications made to ths file will be overwritten by the generated content in nightly runs.
-# For more information, please refer to the page:
-# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
 version: v1.0
 name: build-test-release
 agent:

--- a/.semaphore/cp_dockerfile_promote.yml
+++ b/.semaphore/cp_dockerfile_promote.yml
@@ -1,8 +1,3 @@
-# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
-# template and configurations in service.yml.
-# Any modifications made to ths file will be overwritten by the generated content in nightly runs.
-# For more information, please refer to the page:
-# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
 version: v1.0
 name: build-test-release
 agent:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,8 +1,3 @@
-# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
-# template and configurations in service.yml.
-# Any modifications made to ths file will be overwritten by the generated content in nightly runs.
-# For more information, please refer to the page:
-# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
 version: v1.0
 name: build-test-release
 agent:


### PR DESCRIPTION
The `.semaphore/*.yml` files carry a header claiming they are generated by ServiceBot and overwritten in nightly runs. That is not true for this repo — `service.yml` sets `semaphore.pipeline_enable: false`, so ServiceBot does not manage or regenerate these files. The stale header misleads reviewers and tools (e.g. Copilot flagged PR #408 because of it).

Removes the header from `semaphore.yml`, `cp_dockerfile_build.yml`, and `cp_dockerfile_promote.yml`. No functional change.