### PR TITLE
Add staging Maven repo fallback for utility-belt resolution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,12 +38,25 @@
         <module>alertmanager</module>
     </modules>
 
+    <repositories>
+        <repository>
+            <id>cp-codeartifact-staging</id>
+            <url>https://staging-confluent-packages-maven-654654529379-us-west-2.s3.us-west-2.amazonaws.com/maven</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>utility-belt</artifactId>
-                <version>8.2.2</version>
+                <version>8.3.1</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Why
- `utility-belt`'s "latest" is resolved from staging Maven, which can include RC-only versions not yet promoted (e.g. `8.3.1`, CP 8.3.1 patch release, still RC-2)
- Build's settings.xml has no staging repo configured → resolution fails outright, breaking nightly auto-update PRs since 2026-07-30

## Changes
- Add `cp-codeartifact-staging` as a `<repository>` in `pom.xml` (public S3, no creds needed)
- Bump `utility-belt` to `8.3.1` here to validate against the real failing version

## Notes
- Fix lives in `pom.xml`, so it applies regardless of which settings.xml is active for a given build